### PR TITLE
include ip address to name binding in Reply, if existing

### DIFF
--- a/lib/dhcp_server.mli
+++ b/lib/dhcp_server.mli
@@ -124,7 +124,7 @@ module Input : sig
   type result =
     | Silence (** Input packet didn't belong to us, normal nop event.*)
     | Update of Lease.database (** Lease database update. *)
-    | Reply of Dhcp_wire.pkt * Lease.database
+    | Reply of Dhcp_wire.pkt * Lease.database * (Ipaddr.V4.t * string) option
     (** Reply packet to be sent back and the corresponding lease database to be
         used in case the sent of the reply pkt is successfull *)
     | Warning of string (** An odd event, could be logged. *)

--- a/test/client/test_client.ml
+++ b/test/client/test_client.ml
@@ -63,7 +63,7 @@ let assert_reply p =
   | Warning s | Error s -> Alcotest.fail s
   | Silence -> Alcotest.fail "Silence from the server in response to a request"
   | Update _db -> Alcotest.fail "database update but no reply -- in our context this is likely a bug"
-  | Reply (pkt, db) -> (pkt, db)
+  | Reply (pkt, db, _) -> (pkt, db)
 
 let server_accepts_start_packet () =
   let open Defaults in

--- a/test/test.ml
+++ b/test/test.ml
@@ -331,7 +331,7 @@ let t_discover fixed =
   if verbose then
     printf "\n%s\n%s\n%!" (yellow "<<DISCOVER>>") (pkt_to_string discover_pkt);
   match Input.input_pkt config (Lease.make_db ()) discover_pkt now with
-  | Input.Reply (reply, db) ->
+  | Input.Reply (reply, db, _) ->
     assert (db = (Lease.make_db ()));
     assert (reply.srcmac = mac_t);
     assert (reply.dstmac = mac2_t);
@@ -430,7 +430,7 @@ let t_discover_no_range_fixed () =
     if verbose then
     printf "\n%s\n%s\n%!" (yellow "<<DISCOVER>>") (pkt_to_string discover_pkt);
   match Input.input_pkt config (Lease.make_db ()) discover_pkt now with
-  | Input.Reply (reply, db) ->
+  | Input.Reply (reply, db, _) ->
     assert (db = (Lease.make_db ()));
     assert (reply.srcmac = mac_t);
     assert (reply.dstmac = mac2_t);
@@ -608,7 +608,7 @@ let t_request_fixed () =
     printf "\n%s\n%s\n%!" (yellow "<<REQUEST>>") (pkt_to_string request);
   let db =
     match Input.input_pkt config (Lease.make_db ()) request now with
-    | Input.Reply (reply, db) ->
+    | Input.Reply (reply, db, _) ->
       (* Fixed leases are mocked up, database should be unchanged *)
       assert (db = (Lease.make_db ()));
       let () =
@@ -657,7 +657,7 @@ let t_request_fixed () =
   (* Build a second request from a different client, we should get a NAK. *)
   let request = request_nak_pkt in
   match Input.input_pkt config db request now with
-  | Input.Reply (reply, odb) ->
+  | Input.Reply (reply, odb, _) ->
     assert (db = odb);
     assert ((List.length reply.options) = 4);
     let () = match List.hd reply.options with
@@ -716,7 +716,7 @@ let t_request () =
     printf "\n%s\n%s\n%!" (yellow "<<REQUEST>>") (pkt_to_string request);
   let db =
     match Input.input_pkt config (Lease.make_db ()) request now with
-    | Input.Reply (reply, db) ->
+    | Input.Reply (reply, db, _) ->
       (* Check if our new lease is there *)
       assert (db <> (Lease.make_db ()));
       assert ((List.length (Lease.to_list db)) = 1);
@@ -777,7 +777,7 @@ let t_request () =
   (* Build a second request from a different client, we should get a NAK. *)
   let request = request_nak_pkt in
   match Input.input_pkt config db request now with
-  | Input.Reply (reply, odb) ->
+  | Input.Reply (reply, odb, _) ->
     assert (db = odb);
     assert ((List.length reply.options) = 4);
     let () = match List.hd reply.options with
@@ -843,7 +843,7 @@ let t_request_no_range () =
   if verbose then
     printf "\n%s\n%s\n%!" (yellow "<<REQUEST>>") (pkt_to_string request);
   match Input.input_pkt config (Lease.make_db ()) request now with
-  | Dhcp_server.Input.Reply (reply, db) ->
+  | Dhcp_server.Input.Reply (reply, db, _) ->
     assert (db = (Lease.make_db ()));
     assert ((List.length reply.options) = 4);
     let () = match List.hd reply.options with
@@ -918,7 +918,7 @@ let t_request_no_range_fixed () =
   if verbose then
     printf "\n%s\n%s\n%!" (yellow "<<REQUEST>>") (pkt_to_string request);
   match Input.input_pkt config (Lease.make_db ()) request now with
-  | Input.Reply (reply, db) ->
+  | Input.Reply (reply, db, _) ->
     (* Check if our new lease is there *)
     assert (db = (Lease.make_db ()));
     let () =

--- a/unix/charruad.ml
+++ b/unix/charruad.ml
@@ -101,7 +101,7 @@ let rec input config db link =
       match (input_pkt config db pkt now) with
       | Silence -> return db
       | Update db -> return db
-      | Reply (reply, db) ->
+      | Reply (reply, db, _) ->
         Lwt_rawlink.send_packet link (Dhcp_wire.buf_of_pkt reply)
         >>= fun () ->
         Lwt_log.debug_f "Sent reply packet: %s" (Dhcp_wire.pkt_to_string reply)


### PR DESCRIPTION
what I want to achieve is to register dns records for dhcp leases.  this is an initial hack, I'm not sure what the design should be.

what this does so far:
- extend the `Reply` constructor with `(ipaddr.v4.t * string) option`, used by `input_request`

what should be done
- when a dhcp lease times out, I'd like to know about this, and remove resource records
- i noticed that `garbage_collect` is never called, i.e. the Lease maps never shrink!
- maybe we should also persist [dhcid]( https://tools.ietf.org/html/rfc4701) information in dns to outsource the persistency problem entirely

see https://github.com/mirage/mirage-skeleton/pull/253 for an update of the mirage-skeleton example using [udns](https://github.com/roburio/udns)

I'm happy for any feedback, suggestions, and further development.