### PR TITLE
use {= version} constraints for packages

### DIFF
--- a/charrua-client-lwt.opam
+++ b/charrua-client-lwt.opam
@@ -18,8 +18,8 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "alcotest"     {with-test}
   "cstruct-unix" {with-test}
-  "charrua" {>= "1.0.0"}
-  "charrua-client" {>= "1.0.0"}
+  "charrua" {= version}
+  "charrua-client" {= version}
   "cstruct" {>="3.0.2"}
   "ipaddr" {>="3.0.0"}
   "mirage-random" {>= "1.0.0"}

--- a/charrua-client-mirage.opam
+++ b/charrua-client-mirage.opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "dune" {build & >= "1.0"}
   "ocaml" {>= "4.04.2"}
-  "charrua-client-lwt" {>= "1.0.0"}
+  "charrua-client-lwt" {= version}
   "ipaddr" {>= "3.0.0"}
   "mirage-random" {>= "1.0.0"}
   "mirage-clock"

--- a/charrua-client.opam
+++ b/charrua-client.opam
@@ -19,8 +19,8 @@ depends: [
   "alcotest"     {with-test}
   "cstruct-unix" {with-test}
   "mirage-random-test" {with-test}
-  "charrua-server" {with-test}
-  "charrua" {>= "1.0.0"}
+  "charrua-server" {= version & with-test}
+  "charrua" {= version}
   "cstruct" {>="3.0.2"}
   "ipaddr"
   "macaddr"

--- a/charrua-server.opam
+++ b/charrua-server.opam
@@ -17,7 +17,7 @@ depends: [
   "dune" {build & >= "1.0"}
   "ppx_sexp_conv"
   "menhir"        {build}
-  "charrua"       {>= "1.0.0"}
+  "charrua"       {= version}
   "ocaml"         {>= "4.04.2"}
   "cstruct"       {>= "3.0.1"}
   "sexplib"

--- a/charrua-unix.opam
+++ b/charrua-unix.opam
@@ -14,8 +14,8 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "lwt" {>="3.0.0"}
   "lwt_log"
-  "charrua" {>= "1.0.0"}
-  "charrua-server" {>= "1.0.0"}
+  "charrua" {= version}
+  "charrua-server" {= version}
   "cstruct-unix"
   "cmdliner"
   "rawlink" {>= "1.0"}


### PR DESCRIPTION
i find this much easier than to rethink when we need to bump versions, and in practise, I'm only really willing to support one version across the repository.