### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/charrua-client-lwt.opam
+++ b/charrua-client-lwt.opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "ocaml" {>= "4.04.2"}
   "alcotest"     {with-test}
   "cstruct-unix" {with-test}

--- a/charrua-client-mirage.opam
+++ b/charrua-client-mirage.opam
@@ -13,7 +13,7 @@ build: [
 ]
 
 depends: [
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "ocaml" {>= "4.04.2"}
   "charrua-client-lwt" {= version}
   "ipaddr" {>= "3.0.0"}

--- a/charrua-client.opam
+++ b/charrua-client.opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "ocaml" {>= "4.04.2"}
   "alcotest"     {with-test}
   "cstruct-unix" {with-test}

--- a/charrua-unix.opam
+++ b/charrua-unix.opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "ocaml" {>= "4.04.2"}
   "lwt" {>="3.0.0"}
   "lwt_log"


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.