### PR TITLE
fix API documentation links to point to https://mirage.github.io/charrua (no /api)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Charrua DHCP - a DHCP client, server and wire frame encoder and decoder
 
 
-[![docs](https://img.shields.io/badge/doc-online-blue.svg)](http://mirage.github.io/charrua/api)
+[![docs](https://img.shields.io/badge/doc-online-blue.svg)](https://mirage.github.io/charrua/)
 [![Build Status](https://travis-ci.org/mirage/charrua.svg)](https://travis-ci.org/mirage/charrua)
 
 [charrua](http://www.github.com/mirage/charrua) is an
@@ -23,8 +23,8 @@ southern South America.
 Charrua consists of the single module `Dhcp_wire` responsible for parsing and
 constructing DHCP messages,
 
-You can browse the API for [charrua](http://www.github.com/mirage/charrua) at
-http://mirage.github.io/charrua/api
+You can browse the API for [charrua](https://www.github.com/mirage/charrua) at
+https://mirage.github.io/charrua/
 
 #### Features
 

--- a/charrua-server.opam
+++ b/charrua-server.opam
@@ -5,7 +5,7 @@ license: "ISC"
 homepage: "https://github.com/mirage/charrua"
 bug-reports: "https://github.com/mirage/charrua/issues"
 dev-repo: "git+https://github.com/mirage/charrua.git"
-doc: "https://mirage.github.io/charrua/api"
+doc: "https://mirage.github.io/charrua/"
 
 build: [
   ["dune" "subst"] {pinned}

--- a/charrua.opam
+++ b/charrua.opam
@@ -33,7 +33,7 @@ Charrua consists a single modules, `Dhcp_wire` responsible for parsing and
 constructing DHCP messages
 
 You can browse the API for [charrua](http://www.github.com/mirage/charrua) at
-http://mirage.github.io/charrua/api
+https://mirage.github.io/charrua/
 
 #### Features
 


### PR DESCRIPTION
fixes #106