### PR TITLE
Fix dune warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 _build
 .merlin
 *.swp
+_opam

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### v1.2.1 (2020-05-11)
+
+* Fix minimal dune version (1.4) (#108 @samoht)
+
 ### v1.2.0 (2019-11-01)
 
 * adapt to mirage-protocols 4.0.0 and tcpip 4.0.0 changes (#105 @hannesm)

--- a/charrua-client-lwt.opam
+++ b/charrua-client-lwt.opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "dune" {>= "1.2.0"}
+  "dune" {>= "1.4.0"}
   "ocaml" {>= "4.06.0"}
   "alcotest"     {with-test}
   "cstruct-unix" {with-test}

--- a/charrua-client-mirage.opam
+++ b/charrua-client-mirage.opam
@@ -13,7 +13,7 @@ build: [
 ]
 
 depends: [
-  "dune" {>= "1.2.0"}
+  "dune" {>= "1.4.0"}
   "ocaml" {>= "4.06.0"}
   "charrua-client-lwt" {= version}
   "ipaddr" {>= "4.0.0"}

--- a/charrua-client.opam
+++ b/charrua-client.opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "dune" {>= "1.2.0"}
+  "dune" {>= "1.4.0"}
   "ocaml" {>= "4.06.0"}
   "alcotest"     {with-test}
   "cstruct-unix" {with-test}

--- a/charrua-server.opam
+++ b/charrua-server.opam
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "ocaml"         {>= "4.06.0"}
-  "dune"          {>= "1.2.0"}
+  "dune"          {>= "1.4.0"}
   "ppx_sexp_conv" {>= "v0.9.0"}
   "menhir"        {build}
   "charrua"       {= version}

--- a/charrua-unix.opam
+++ b/charrua-unix.opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "dune" {>= "1.2.0"}
+  "dune" {>= "1.4.0"}
   "ocaml" {>= "4.06.0"}
   "lwt" {>="3.0.0"}
   "lwt_log"

--- a/charrua.opam
+++ b/charrua.opam
@@ -14,7 +14,7 @@ build: [
 
 depends: [
   "ocaml"         {>= "4.06.0"}
-  "dune"          {>= "1.2.0"}
+  "dune"          {>= "1.4.0"}
   "ppx_sexp_conv" {>="v0.10.0"}
   "ppx_cstruct"
   "cstruct"       {>= "3.0.1"}

--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,3 @@
-(lang dune 1.2)
+(lang dune 1.4)
 (name charrua)
 (using menhir 2.0)


### PR DESCRIPTION
Otherwise building the project gives:

```
$ dune build
File "dune-project", line 3, characters 14-17:
3 | (using menhir 2.0)
                  ^^^
Warning: Version 2.0 of the menhir extension is not supported until version
1.4 of the dune language.
Supported versions of this extension in version 1.2 of the dune language:
- 1.0
```