### PR TITLE
Adapt unix/charruad to newer cmdliner.

### DIFF
--- a/charrua-unix.opam
+++ b/charrua-unix.opam
@@ -16,7 +16,7 @@ depends: [
   "charrua" {= version}
   "charrua-server" {= version}
   "cstruct-unix"
-  "cmdliner"
+  "cmdliner" {>= "1.1.0"}
   "rawlink" {>= "1.0"}
   "tuntap" {>= "2.0.0"}
   "mtime" {>= "1.0.0"}

--- a/lib/dhcp_wire.ml
+++ b/lib/dhcp_wire.ml
@@ -1206,7 +1206,7 @@ let pkt_into_buf pkt buf =
    | Error e -> invalid_arg e) ;
   (match Ipv4_packet.(Marshal.into_cstruct ~payload_len
                           { src = pkt.srcip; dst = pkt.dstip;
-                            id = 0 (* TODO: random? *); off = 0 ;
+                            id = 0; off = 0 ;
                             proto = (Marshal.protocol_to_int `UDP);
                             ttl = 255;
                             options = Cstruct.create 0; }

--- a/unix/charruad.ml
+++ b/unix/charruad.ml
@@ -200,7 +200,7 @@ let cmd =
   let daemonize = Arg.(value & flag & info ["D" ; "daemon"]
                          ~doc:"Daemonize.") in
   Cmd.v
-    (Cmd.info "charruad" ~version:"0.1" ~doc:"Charrua DHCPD")
+    (Cmd.info "charruad" ~version:"%%VERSION%%" ~doc:"Charrua DHCPD")
     Term.(const charruad $ configfile $ group $ pidfile $ user $ verbosity $ daemonize)
 
 let () = exit (Cmd.eval cmd)

--- a/unix/charruad.ml
+++ b/unix/charruad.ml
@@ -199,12 +199,8 @@ let cmd =
                          ~doc:"Log verbosity, warning|notice|debug") in
   let daemonize = Arg.(value & flag & info ["D" ; "daemon"]
                          ~doc:"Daemonize.") in
-  (* let color = *)
-  (*   let when_enum = [ "always", `Always; "never", `Never; "auto", `Auto ] in *)
-  (*   let doc = Arg.info ~docv:"WHEN" *)
-  (*       ~doc:(Printf.sprintf "Colorize the output. $(docv) must be %s." *)
-  (*               (Arg.doc_alts_enum when_enum)) ["color"] in *)
-  (*   Arg.(value & opt (enum when_enum) `Auto & doc) in *)
-  Term.(pure charruad $ configfile $ group $ pidfile $ user $ verbosity $ daemonize),
-  Term.info "charruad" ~version:"0.1" ~doc:"Charrua DHCPD"
-let () = match Term.eval cmd with `Error _ -> exit 1 | _ -> exit 0
+  Cmd.v
+    (Cmd.info "charruad" ~version:"0.1" ~doc:"Charrua DHCPD")
+    Term.(const charruad $ configfile $ group $ pidfile $ user $ verbosity $ daemonize)
+
+let () = exit (Cmd.eval cmd)


### PR DESCRIPTION
Syntax changed, so also constrict cmdliner version to >= 1.1.0