### PR TITLE
Add support for Mtime 2.0.0

### DIFF
--- a/charrua-unix-eio.opam
+++ b/charrua-unix-eio.opam
@@ -19,7 +19,7 @@ depends: [
   "eio_main" {>= "0.4"}
   "rawlink-eio" {>= "2.0"}
   "tuntap" {>= "2.0.0"}
-  "mtime" {>= "1.0.0" & < "2.0.0"}
+  "mtime" {>= "2.0.0"}
   "ipaddr" {>= "5.1.0"}
   "tcpip" {>= "7.0.0"}
   "logs-syslog" {>= "0.3.1"}

--- a/charrua-unix-eio.opam
+++ b/charrua-unix-eio.opam
@@ -19,9 +19,10 @@ depends: [
   "eio_main" {>= "0.4"}
   "rawlink-eio" {>= "2.0"}
   "tuntap" {>= "2.0.0"}
-  "mtime" {>= "1.0.0"}
+  "mtime" {>= "1.0.0" & < "2.0.0"}
   "ipaddr" {>= "5.1.0"}
   "tcpip" {>= "7.0.0"}
+  "logs-syslog" {>= "0.3.1"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/charrua-unix.opam
+++ b/charrua-unix.opam
@@ -19,7 +19,7 @@ depends: [
   "cmdliner" {>= "1.1.0"}
   "rawlink-lwt" {>= "2.0"}
   "tuntap" {>= "2.0.0"}
-  "mtime" {>= "1.0.0" & < "2.0.0"}
+  "mtime" {>= "2.0.0"}
   "cstruct-lwt" {>= "6.0.0"}
   "ipaddr" {>= "5.1.0"}
   "tcpip" {>= "7.0.0"}

--- a/charrua-unix.opam
+++ b/charrua-unix.opam
@@ -19,7 +19,7 @@ depends: [
   "cmdliner" {>= "1.1.0"}
   "rawlink-lwt" {>= "2.0"}
   "tuntap" {>= "2.0.0"}
-  "mtime" {>= "1.0.0"}
+  "mtime" {>= "1.0.0" & < "2.0.0"}
   "cstruct-lwt" {>= "6.0.0"}
   "ipaddr" {>= "5.1.0"}
   "tcpip" {>= "7.0.0"}

--- a/unix/charruad.ml
+++ b/unix/charruad.ml
@@ -85,7 +85,7 @@ let init_log vlevel daemon =
         ()
 
 let uptime_in_sec () =
-  Mtime_clock.elapsed () |> Mtime.Span.to_s |> Int.of_float
+  Int64.div (Mtime_clock.elapsed_ns ()) (Int64.of_int 1_000_000_000) |> Int64.to_int
 
 let maybe_gc db now gbcol =
   let open Lwt in

--- a/unix/charruad_eio.ml
+++ b/unix/charruad_eio.ml
@@ -82,7 +82,7 @@ let init_log level daemon =
   Result.get_ok @@ Logs.level_of_string level
 
 let uptime_in_sec () =
-  Mtime_clock.elapsed () |> Mtime.Span.to_s |> Int.of_float
+  Int64.div (Mtime_clock.elapsed_ns ()) (Int64.of_int 1_000_000_000) |> Int64.to_int
 
 let maybe_gc db now gbcol =
   if (now - gbcol) >= 60 then


### PR DESCRIPTION
This PR adds an upper bound on mtime library and includes a missing logs-syslog dependency for EIO.