### PR TITLE
charrua-unix: use duration, avoid manual nano-second conversion

### DIFF
--- a/charrua-unix-eio.opam
+++ b/charrua-unix-eio.opam
@@ -20,6 +20,7 @@ depends: [
   "rawlink-eio" {>= "2.0"}
   "tuntap" {>= "2.0.0"}
   "mtime" {>= "2.0.0"}
+  "duration"
   "ipaddr" {>= "5.1.0"}
   "tcpip" {>= "7.0.0"}
   "logs-syslog" {>= "0.3.1"}

--- a/charrua-unix.opam
+++ b/charrua-unix.opam
@@ -20,6 +20,7 @@ depends: [
   "rawlink-lwt" {>= "2.0"}
   "tuntap" {>= "2.0.0"}
   "mtime" {>= "2.0.0"}
+  "duration"
   "cstruct-lwt" {>= "6.0.0"}
   "ipaddr" {>= "5.1.0"}
   "tcpip" {>= "7.0.0"}

--- a/unix/charruad.ml
+++ b/unix/charruad.ml
@@ -85,7 +85,7 @@ let init_log vlevel daemon =
         ()
 
 let uptime_in_sec () =
-  Int64.div (Mtime_clock.elapsed_ns ()) (Int64.of_int 1_000_000_000) |> Int64.to_int
+  Duration.to_sec (Mtime_clock.elapsed_ns ())
 
 let maybe_gc db now gbcol =
   let open Lwt in

--- a/unix/charruad_eio.ml
+++ b/unix/charruad_eio.ml
@@ -82,7 +82,7 @@ let init_log level daemon =
   Result.get_ok @@ Logs.level_of_string level
 
 let uptime_in_sec () =
-  Int64.div (Mtime_clock.elapsed_ns ()) (Int64.of_int 1_000_000_000) |> Int64.to_int
+  Duration.to_sec (Mtime_clock.elapsed_ns ())
 
 let maybe_gc db now gbcol =
   if (now - gbcol) >= 60 then

--- a/unix/dune
+++ b/unix/dune
@@ -4,7 +4,7 @@
  (public_name charruad)
  (package charrua-unix)
  (libraries charrua charrua-server lwt.unix cstruct-lwt cstruct-unix cmdliner
-   ipaddr tuntap rawlink-lwt mtime.clock.os lwt_log))
+   ipaddr tuntap rawlink-lwt mtime.clock.os lwt_log duration))
 
 (executable
  (name charruad_eio)
@@ -13,4 +13,4 @@
  (package charrua-unix-eio)
  (libraries charrua charrua-server cstruct-unix cmdliner
    eio_main ipaddr tuntap rawlink-eio mtime.clock.os
-   logs-syslog logs-syslog.unix))
+   logs-syslog logs-syslog.unix duration))


### PR DESCRIPTION
/cc @haesbaert this is what I had in mind with #121 :)