### PR TITLE
Remove ppx_cstruct, ppx_sexp_conv, and sexplib from dependencies, shorten options

### DIFF
--- a/charrua-server.opam
+++ b/charrua-server.opam
@@ -39,7 +39,6 @@ depends: [
   "ipaddr-sexp"
   "macaddr-sexp"
   "cstruct-unix" {with-test}
-  "ppx_cstruct" {>= "6.0.0" & with-test}
   "tcpip" {>= "7.0.0" & with-test}
   "alcotest" {with-test & >= "1.4.0"}
 ]

--- a/charrua-server.opam
+++ b/charrua-server.opam
@@ -29,15 +29,11 @@ bug-reports: "https://github.com/mirage/charrua/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "1.4.0"}
-  "ppx_sexp_conv" {>= "v0.9.0"}
   "menhir" {build & >= "20180523"}
   "charrua" {= version}
   "cstruct" {>= "6.0.0"}
-  "sexplib"
   "ipaddr" {>= "5.0.0"}
   "macaddr" {>= "4.0.0"}
-  "ipaddr-sexp"
-  "macaddr-sexp"
   "cstruct-unix" {with-test}
   "tcpip" {>= "7.0.0" & with-test}
   "alcotest" {with-test & >= "1.4.0"}

--- a/charrua.opam
+++ b/charrua.opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml"         {>= "4.08.0"}
   "dune"          {>= "1.4.0"}
   "ppx_sexp_conv" {>="v0.10.0"}
-  "ppx_cstruct"
   "cstruct"       {>= "6.0.0"}
   "sexplib"
   "ipaddr"        {>= "5.0.0"}

--- a/charrua.opam
+++ b/charrua.opam
@@ -15,15 +15,12 @@ build: [
 depends: [
   "ocaml"         {>= "4.08.0"}
   "dune"          {>= "1.4.0"}
-  "ppx_sexp_conv" {>="v0.10.0"}
   "cstruct"       {>= "6.0.0"}
-  "sexplib"
   "ipaddr"        {>= "5.0.0"}
   "macaddr"       {>= "4.0.0"}
-  "ipaddr-sexp"
-  "macaddr-sexp"
   "ethernet"      {>= "3.0.0"}
   "tcpip"         {>= "7.0.0"}
+  "ohex"          {>= "0.2.0"}
 ]
 conflicts: [ "result" {< "1.5"} ]
 synopsis: "DHCP wire frame encoder and decoder"

--- a/client/dhcp_client.ml
+++ b/client/dhcp_client.ml
@@ -64,14 +64,17 @@ let default_requests =
 
 (* a pretty-printer for the client, useful for debugging and logging. *)
 let pp fmt p =
-  let pr = Dhcp_wire.pkt_to_string in
   let pp_state fmt = function
-    | Selecting pkt -> Format.fprintf fmt "SELECTING.  Generated %s" @@ pr pkt
-    | Requesting (received, sent) -> Format.fprintf fmt
-        "REQUESTING. Received %s, and generated response %s" (pr received) (pr sent)
-    | Bound pkt -> Format.fprintf fmt "BOUND.  Received %s" @@ pr pkt
-    | Renewing (ack, request) -> Format.fprintf fmt
-        "RENEWING.  Have lease %s, generated request %s" (pr ack) (pr request)
+    | Selecting pkt -> Format.fprintf fmt "SELECTING.  Generated %a" Dhcp_wire.pp_pkt pkt
+    | Requesting (received, sent) ->
+      Format.fprintf fmt
+        "REQUESTING. Received %a, and generated response %a"
+        Dhcp_wire.pp_pkt received Dhcp_wire.pp_pkt sent
+    | Bound pkt -> Format.fprintf fmt "BOUND.  Received %a" Dhcp_wire.pp_pkt pkt
+    | Renewing (ack, request) ->
+      Format.fprintf fmt
+        "RENEWING.  Have lease %a, generated request %a"
+        Dhcp_wire.pp_pkt ack Dhcp_wire.pp_pkt request
   in
   Format.fprintf fmt "%a: %a" Macaddr.pp p.srcmac pp_state p.state
 

--- a/client/mirage/dhcp_client_mirage.ml
+++ b/client/mirage/dhcp_client_mirage.ml
@@ -9,7 +9,7 @@ let config_of_lease lease =
   match Dhcp_wire.find_subnet_mask lease.options with
   | None ->
     Log.info (fun f -> f "Lease obtained with no subnet mask; discarding it");
-    Log.debug (fun f -> f "Unusable lease: %s" @@ Dhcp_wire.pkt_to_string lease);
+    Log.debug (fun f -> f "Unusable lease: %a" Dhcp_wire.pp_pkt lease);
     None
   | Some subnet ->
     match Ipaddr.V4.Prefix.of_netmask ~netmask:subnet ~address with

--- a/lib/dhcp_wire.ml
+++ b/lib/dhcp_wire.ml
@@ -200,17 +200,11 @@ type option_code =
   | SUBNET_MASK [@id 1]
   | TIME_OFFSET [@id 2]
   | ROUTERS [@id 3]
-  | TIME_SERVERS [@id 4]
-  | NAME_SERVERS [@id 5]
   | DNS_SERVERS [@id 6]
   | LOG_SERVERS [@id 7]
-  | COOKIE_SERVERS [@id 8]
   | LPR_SERVERS [@id 9]
-  | IMPRESS_SERVERS [@id 10]
-  | RSCLOCATION_SERVERS [@id 11]
   | HOSTNAME [@id 12]
   | BOOTFILE_SIZE [@id 13]
-  | MERIT_DUMPFILE [@id 14]
   | DOMAIN_NAME [@id 15]
   | SWAP_SERVER [@id 16]
   | ROOT_PATH [@id 17]
@@ -220,13 +214,9 @@ type option_code =
   | POLICY_FILTERS [@id 21]
   | MAX_DATAGRAM [@id 22]
   | DEFAULT_IP_TTL [@id 23]
-  | PMTU_AGEING_TIMO [@id 24]
-  | PMTU_PLATEAU_TABLE [@id 25]
   | INTERFACE_MTU [@id 26]
   | ALL_SUBNETS_LOCAL [@id 27]
   | BROADCAST_ADDR [@id 28]
-  | PERFORM_MASK_DISCOVERY [@id 29]
-  | MASK_SUPPLIER [@id 30]
   | PERFORM_ROUTER_DISC [@id 31]
   | ROUTER_SOL_ADDR [@id 32]
   | STATIC_ROUTES [@id 33]
@@ -235,7 +225,6 @@ type option_code =
   | ETHERNET_ENCAPSULATION [@id 36]
   | TCP_DEFAULT_TTL [@id 37]
   | TCP_KEEPALIVE_INTERVAL [@id 38]
-  | TCP_KEEPALIVE_GARBAGE [@id 39]
   | NIS_DOMAIN [@id 40]
   | NIS_SERVERS [@id 41]
   | NTP_SERVERS [@id 42]
@@ -258,8 +247,6 @@ type option_code =
   | REBINDING_T2 [@id 59]
   | VENDOR_CLASS_ID [@id 60]
   | CLIENT_ID [@id 61]
-  | NETWARE_IP_DOMAIN [@id 62]
-  | NETWARE_IP_OPTION [@id 63]
   | NIS_PLUS_DOMAIN [@id 64]
   | NIS_PLUS_SERVERS [@id 65]
   | TFTP_SERVER_NAME [@id 66]
@@ -268,87 +255,23 @@ type option_code =
   | SMTP_SERVERS [@id 69]
   | POP3_SERVERS [@id 70]
   | NNTP_SERVERS [@id 71]
-  | WWW_SERVERS [@id 72]
-  | FINGER_SERVERS [@id 73]
   | IRC_SERVERS [@id 74]
-  | STREETTALK_SERVERS [@id 75]
-  | STREETTALK_DA [@id 76]
   | USER_CLASS [@id 77]
-  | DIRECTORY_AGENT [@id 78]
-  | SERVICE_SCOPE [@id 79]
   | RAPID_COMMIT [@id 80]
   | CLIENT_FQDN [@id 81]
   | RELAY_AGENT_INFORMATION [@id 82]
-  | ISNS [@id 83]
-  | NDS_SERVERS [@id 85]
-  | NDS_TREE_NAME [@id 86]
-  | NDS_CONTEXT [@id 87]
-  | BCMCS_CONTROLLER_DOMAIN_NAME_LIST [@id 88]
-  | BCMCS_CONTROLLER_IPV4_ADDR [@id 89]
-  | AUTHENTICATION [@id 90]
-  | CLIENT_LAST_TRANSACTION_TIME [@id 91]
-  | ASSOCIATED_IPS [@id 92]
   | CLIENT_SYSTEM [@id 93]
   | CLIENT_NDI [@id 94]
-  | LDAP [@id 95]
   | UUID_GUID [@id 97]
-  | USER_AUTH [@id 98]
-  | GEOCONF_CIVIC [@id 99]
   | PCODE [@id 100]
   | TCODE [@id 101]
-  | NETINFO_ADDRESS [@id 112]
-  | NETINFO_TAG [@id 113]
-  | URL [@id 114]
-  | AUTO_CONFIG [@id 116]
-  | NAME_SERVICE_SEARCH [@id 117]
+  | IPV6ONLY [@id 108]
   | SUBNET_SELECTION [@id 118]
   | DOMAIN_SEARCH [@id 119]
   | SIP_SERVERS [@id 120]
   | CLASSLESS_STATIC_ROUTE [@id 121]
-  | CCC [@id 122]
-  | GEOCONF [@id 123]
-  | VI_VENDOR_CLASS [@id 124]
   | VI_VENDOR_INFO [@id 125]
-  | PXE_128 [@id 128]
-  | PXE_129 [@id 129]
-  | PXE_130 [@id 130]
-  | PXE_131 [@id 131]
-  | PXE_132 [@id 132]
-  | PXE_133 [@id 133]
-  | PXE_134 [@id 134]
-  | PXE_135 [@id 135]
-  | PANA_AGENT [@id 136]
-  | V4_LOST [@id 137]
-  | CAPWAP_AC_V4 [@id 138]
-  | IPV4_ADDRESS_MOS [@id 139]
-  | IPV4_FQDN_MOS [@id 140]
-  | SIP_UA_DOMAINS [@id 141]
-  | IPV4_ADDRESS_ANDSF [@id 142]
-  | GEOLOCK [@id 144]
-  | FORCENEW_NONCE_CAPABLE [@id 145]
-  | RDNSS_SELECTION [@id 146]
   | MISC_150 [@id 150]
-  | STATUS_CODE [@id 151]
-  | ABSOLUTE_TIME [@id 152]
-  | START_TIME_OF_STATE [@id 153]
-  | QUERY_START_TIME [@id 154]
-  | QUERY_END_TIME [@id 155]
-  | DHCP_STATE [@id 156]
-  | DATA_SOURCE [@id 157]
-  | V4_PCP_SERVER [@id 158]
-  | V4_PORTPARAMS [@id 159]
-  | DHCP_CAPTIVE_PORTAL [@id 160]
-  | ETHERBOOT_175 [@id 175]
-  | IP_TELEFONE [@id 176]
-  | ETHERBOOT_177 [@id 177]
-  | PXE_LINUX [@id 208]
-  | CONFIGURATION_FILE [@id 209]
-  | PATH_PREFIX [@id 210]
-  | REBOOT_TIME [@id 211]
-  | OPTION_6RD [@id 212]
-  | V4_ACCESS_DOMAIN [@id 213]
-  | SUBNET_ALLOCATION [@id 220]
-  | VIRTUAL_SUBNET_SELECTION [@id 221]
   | PRIVATE_CLASSLESS_STATIC_ROUTE [@id 249]
   | WEB_PROXY_AUTO_DISC [@id 252]
   | END [@id 255]
@@ -359,17 +282,11 @@ let int_to_option_code = function
   | 1 -> Some SUBNET_MASK
   | 2 -> Some TIME_OFFSET
   | 3 -> Some ROUTERS
-  | 4 -> Some TIME_SERVERS
-  | 5 -> Some NAME_SERVERS
   | 6 -> Some DNS_SERVERS
   | 7 -> Some LOG_SERVERS
-  | 8 -> Some COOKIE_SERVERS
   | 9 -> Some LPR_SERVERS
-  | 10 -> Some IMPRESS_SERVERS
-  | 11 -> Some RSCLOCATION_SERVERS
   | 12 -> Some HOSTNAME
   | 13 -> Some BOOTFILE_SIZE
-  | 14 -> Some MERIT_DUMPFILE
   | 15 -> Some DOMAIN_NAME
   | 16 -> Some SWAP_SERVER
   | 17 -> Some ROOT_PATH
@@ -379,13 +296,9 @@ let int_to_option_code = function
   | 21 -> Some POLICY_FILTERS
   | 22 -> Some MAX_DATAGRAM
   | 23 -> Some DEFAULT_IP_TTL
-  | 24 -> Some PMTU_AGEING_TIMO
-  | 25 -> Some PMTU_PLATEAU_TABLE
   | 26 -> Some INTERFACE_MTU
   | 27 -> Some ALL_SUBNETS_LOCAL
   | 28 -> Some BROADCAST_ADDR
-  | 29 -> Some PERFORM_MASK_DISCOVERY
-  | 30 -> Some MASK_SUPPLIER
   | 31 -> Some PERFORM_ROUTER_DISC
   | 32 -> Some ROUTER_SOL_ADDR
   | 33 -> Some STATIC_ROUTES
@@ -394,7 +307,6 @@ let int_to_option_code = function
   | 36 -> Some ETHERNET_ENCAPSULATION
   | 37 -> Some TCP_DEFAULT_TTL
   | 38 -> Some TCP_KEEPALIVE_INTERVAL
-  | 39 -> Some TCP_KEEPALIVE_GARBAGE
   | 40 -> Some NIS_DOMAIN
   | 41 -> Some NIS_SERVERS
   | 42 -> Some NTP_SERVERS
@@ -417,8 +329,6 @@ let int_to_option_code = function
   | 59 -> Some REBINDING_T2
   | 60 -> Some VENDOR_CLASS_ID
   | 61 -> Some CLIENT_ID
-  | 62 -> Some NETWARE_IP_DOMAIN
-  | 63 -> Some NETWARE_IP_OPTION
   | 64 -> Some NIS_PLUS_DOMAIN
   | 65 -> Some NIS_PLUS_SERVERS
   | 66 -> Some TFTP_SERVER_NAME
@@ -427,87 +337,23 @@ let int_to_option_code = function
   | 69 -> Some SMTP_SERVERS
   | 70 -> Some POP3_SERVERS
   | 71 -> Some NNTP_SERVERS
-  | 72 -> Some WWW_SERVERS
-  | 73 -> Some FINGER_SERVERS
   | 74 -> Some IRC_SERVERS
-  | 75 -> Some STREETTALK_SERVERS
-  | 76 -> Some STREETTALK_DA
   | 77 -> Some USER_CLASS
-  | 78 -> Some DIRECTORY_AGENT
-  | 79 -> Some SERVICE_SCOPE
   | 80 -> Some RAPID_COMMIT
   | 81 -> Some CLIENT_FQDN
   | 82 -> Some RELAY_AGENT_INFORMATION
-  | 83 -> Some ISNS
-  | 85 -> Some NDS_SERVERS
-  | 86 -> Some NDS_TREE_NAME
-  | 87 -> Some NDS_CONTEXT
-  | 88 -> Some BCMCS_CONTROLLER_DOMAIN_NAME_LIST
-  | 89 -> Some BCMCS_CONTROLLER_IPV4_ADDR
-  | 90 -> Some AUTHENTICATION
-  | 91 -> Some CLIENT_LAST_TRANSACTION_TIME
-  | 92 -> Some ASSOCIATED_IPS
   | 93 -> Some CLIENT_SYSTEM
   | 94 -> Some CLIENT_NDI
-  | 95 -> Some LDAP
   | 97 -> Some UUID_GUID
-  | 98 -> Some USER_AUTH
-  | 99 -> Some GEOCONF_CIVIC
   | 100 -> Some PCODE
   | 101 -> Some TCODE
-  | 112 -> Some NETINFO_ADDRESS
-  | 113 -> Some NETINFO_TAG
-  | 114 -> Some URL
-  | 116 -> Some AUTO_CONFIG
-  | 117 -> Some NAME_SERVICE_SEARCH
+  | 108 -> Some IPV6ONLY
   | 118 -> Some SUBNET_SELECTION
   | 119 -> Some DOMAIN_SEARCH
   | 120 -> Some SIP_SERVERS
   | 121 -> Some CLASSLESS_STATIC_ROUTE
-  | 122 -> Some CCC
-  | 123 -> Some GEOCONF
-  | 124 -> Some VI_VENDOR_CLASS
   | 125 -> Some VI_VENDOR_INFO
-  | 128 -> Some PXE_128
-  | 129 -> Some PXE_129
-  | 130 -> Some PXE_130
-  | 131 -> Some PXE_131
-  | 132 -> Some PXE_132
-  | 133 -> Some PXE_133
-  | 134 -> Some PXE_134
-  | 135 -> Some PXE_135
-  | 136 -> Some PANA_AGENT
-  | 137 -> Some V4_LOST
-  | 138 -> Some CAPWAP_AC_V4
-  | 139 -> Some IPV4_ADDRESS_MOS
-  | 140 -> Some IPV4_FQDN_MOS
-  | 141 -> Some SIP_UA_DOMAINS
-  | 142 -> Some IPV4_ADDRESS_ANDSF
-  | 144 -> Some GEOLOCK
-  | 145 -> Some FORCENEW_NONCE_CAPABLE
-  | 146 -> Some RDNSS_SELECTION
   | 150 -> Some MISC_150
-  | 151 -> Some STATUS_CODE
-  | 152 -> Some ABSOLUTE_TIME
-  | 153 -> Some START_TIME_OF_STATE
-  | 154 -> Some QUERY_START_TIME
-  | 155 -> Some QUERY_END_TIME
-  | 156 -> Some DHCP_STATE
-  | 157 -> Some DATA_SOURCE
-  | 158 -> Some V4_PCP_SERVER
-  | 159 -> Some V4_PORTPARAMS
-  | 160 -> Some DHCP_CAPTIVE_PORTAL
-  | 175 -> Some ETHERBOOT_175
-  | 176 -> Some IP_TELEFONE
-  | 177 -> Some ETHERBOOT_177
-  | 208 -> Some PXE_LINUX
-  | 209 -> Some CONFIGURATION_FILE
-  | 210 -> Some PATH_PREFIX
-  | 211 -> Some REBOOT_TIME
-  | 212 -> Some OPTION_6RD
-  | 213 -> Some V4_ACCESS_DOMAIN
-  | 220 -> Some SUBNET_ALLOCATION
-  | 221 -> Some VIRTUAL_SUBNET_SELECTION
   | 249 -> Some PRIVATE_CLASSLESS_STATIC_ROUTE
   | 252 -> Some WEB_PROXY_AUTO_DISC
   | 255 -> Some END
@@ -520,17 +366,11 @@ let option_code_to_int = function
   | SUBNET_MASK -> 1
   | TIME_OFFSET -> 2
   | ROUTERS -> 3
-  | TIME_SERVERS -> 4
-  | NAME_SERVERS -> 5
   | DNS_SERVERS -> 6
   | LOG_SERVERS -> 7
-  | COOKIE_SERVERS -> 8
   | LPR_SERVERS -> 9
-  | IMPRESS_SERVERS -> 10
-  | RSCLOCATION_SERVERS -> 11
   | HOSTNAME -> 12
   | BOOTFILE_SIZE -> 13
-  | MERIT_DUMPFILE -> 14
   | DOMAIN_NAME -> 15
   | SWAP_SERVER -> 16
   | ROOT_PATH -> 17
@@ -540,13 +380,9 @@ let option_code_to_int = function
   | POLICY_FILTERS -> 21
   | MAX_DATAGRAM -> 22
   | DEFAULT_IP_TTL -> 23
-  | PMTU_AGEING_TIMO -> 24
-  | PMTU_PLATEAU_TABLE -> 25
   | INTERFACE_MTU -> 26
   | ALL_SUBNETS_LOCAL -> 27
   | BROADCAST_ADDR -> 28
-  | PERFORM_MASK_DISCOVERY -> 29
-  | MASK_SUPPLIER -> 30
   | PERFORM_ROUTER_DISC -> 31
   | ROUTER_SOL_ADDR -> 32
   | STATIC_ROUTES -> 33
@@ -555,7 +391,6 @@ let option_code_to_int = function
   | ETHERNET_ENCAPSULATION -> 36
   | TCP_DEFAULT_TTL -> 37
   | TCP_KEEPALIVE_INTERVAL -> 38
-  | TCP_KEEPALIVE_GARBAGE -> 39
   | NIS_DOMAIN -> 40
   | NIS_SERVERS -> 41
   | NTP_SERVERS -> 42
@@ -578,8 +413,6 @@ let option_code_to_int = function
   | REBINDING_T2 -> 59
   | VENDOR_CLASS_ID -> 60
   | CLIENT_ID -> 61
-  | NETWARE_IP_DOMAIN -> 62
-  | NETWARE_IP_OPTION -> 63
   | NIS_PLUS_DOMAIN -> 64
   | NIS_PLUS_SERVERS -> 65
   | TFTP_SERVER_NAME -> 66
@@ -588,87 +421,23 @@ let option_code_to_int = function
   | SMTP_SERVERS -> 69
   | POP3_SERVERS -> 70
   | NNTP_SERVERS -> 71
-  | WWW_SERVERS -> 72
-  | FINGER_SERVERS -> 73
   | IRC_SERVERS -> 74
-  | STREETTALK_SERVERS -> 75
-  | STREETTALK_DA -> 76
   | USER_CLASS -> 77
-  | DIRECTORY_AGENT -> 78
-  | SERVICE_SCOPE -> 79
   | RAPID_COMMIT -> 80
   | CLIENT_FQDN -> 81
   | RELAY_AGENT_INFORMATION -> 82
-  | ISNS -> 83
-  | NDS_SERVERS -> 85
-  | NDS_TREE_NAME -> 86
-  | NDS_CONTEXT -> 87
-  | BCMCS_CONTROLLER_DOMAIN_NAME_LIST -> 88
-  | BCMCS_CONTROLLER_IPV4_ADDR -> 89
-  | AUTHENTICATION -> 90
-  | CLIENT_LAST_TRANSACTION_TIME -> 91
-  | ASSOCIATED_IPS -> 92
   | CLIENT_SYSTEM -> 93
   | CLIENT_NDI -> 94
-  | LDAP -> 95
   | UUID_GUID -> 97
-  | USER_AUTH -> 98
-  | GEOCONF_CIVIC -> 99
   | PCODE -> 100
   | TCODE -> 101
-  | NETINFO_ADDRESS -> 112
-  | NETINFO_TAG -> 113
-  | URL -> 114
-  | AUTO_CONFIG -> 116
-  | NAME_SERVICE_SEARCH -> 117
+  | IPV6ONLY -> 108
   | SUBNET_SELECTION -> 118
   | DOMAIN_SEARCH -> 119
   | SIP_SERVERS -> 120
   | CLASSLESS_STATIC_ROUTE -> 121
-  | CCC -> 122
-  | GEOCONF -> 123
-  | VI_VENDOR_CLASS -> 124
   | VI_VENDOR_INFO -> 125
-  | PXE_128 -> 128
-  | PXE_129 -> 129
-  | PXE_130 -> 130
-  | PXE_131 -> 131
-  | PXE_132 -> 132
-  | PXE_133 -> 133
-  | PXE_134 -> 134
-  | PXE_135 -> 135
-  | PANA_AGENT -> 136
-  | V4_LOST -> 137
-  | CAPWAP_AC_V4 -> 138
-  | IPV4_ADDRESS_MOS -> 139
-  | IPV4_FQDN_MOS -> 140
-  | SIP_UA_DOMAINS -> 141
-  | IPV4_ADDRESS_ANDSF -> 142
-  | GEOLOCK -> 144
-  | FORCENEW_NONCE_CAPABLE -> 145
-  | RDNSS_SELECTION -> 146
   | MISC_150 -> 150
-  | STATUS_CODE -> 151
-  | ABSOLUTE_TIME -> 152
-  | START_TIME_OF_STATE -> 153
-  | QUERY_START_TIME -> 154
-  | QUERY_END_TIME -> 155
-  | DHCP_STATE -> 156
-  | DATA_SOURCE -> 157
-  | V4_PCP_SERVER -> 158
-  | V4_PORTPARAMS -> 159
-  | DHCP_CAPTIVE_PORTAL -> 160
-  | ETHERBOOT_175 -> 175
-  | IP_TELEFONE -> 176
-  | ETHERBOOT_177 -> 177
-  | PXE_LINUX -> 208
-  | CONFIGURATION_FILE -> 209
-  | PATH_PREFIX -> 210
-  | REBOOT_TIME -> 211
-  | OPTION_6RD -> 212
-  | V4_ACCESS_DOMAIN -> 213
-  | SUBNET_ALLOCATION -> 220
-  | VIRTUAL_SUBNET_SELECTION -> 221
   | PRIVATE_CLASSLESS_STATIC_ROUTE -> 249
   | WEB_PROXY_AUTO_DISC -> 252
   | END -> 255
@@ -691,17 +460,11 @@ type dhcp_option =
   | Subnet_mask of Ipaddr_sexp.V4.t         (* code 1 *)
   | Time_offset of int32                    (* code 2 *)
   | Routers of Ipaddr_sexp.V4.t list        (* code 3 *)
-  | Time_servers of Ipaddr_sexp.V4.t list        (* code 4 *)
-  | Name_servers of Ipaddr_sexp.V4.t list        (* code 5 *)
   | Dns_servers of Ipaddr_sexp.V4.t list         (* code 6 *)
   | Log_servers of Ipaddr_sexp.V4.t list         (* code 7 *)
-  | Cookie_servers of Ipaddr_sexp.V4.t list      (* code 8 *)
   | Lpr_servers of Ipaddr_sexp.V4.t list         (* code 9 *)
-  | Impress_servers of Ipaddr_sexp.V4.t list     (* code 10 *)
-  | Rsclocation_servers of Ipaddr_sexp.V4.t list (* code 11 *)
   | Hostname of string                      (* code 12 *)
   | Bootfile_size of int                    (* code 13 *)
-  | Merit_dumpfile of string                (* code 14 *)
   | Domain_name of string                   (* code 15 *)
   | Swap_server of Ipaddr_sexp.V4.t              (* code 16 *)
   | Root_path of string                     (* code 17 *)
@@ -711,13 +474,9 @@ type dhcp_option =
   | Policy_filters of Ipaddr_sexp.V4.Prefix.t list (* code 21 *)
   | Max_datagram of int                     (* code 22 *)
   | Default_ip_ttl of int                   (* code 23 *)
-  | Pmtu_ageing_timo of int32               (* code 24 *)
-  | Pmtu_plateau_table of int list          (* code 25 *)
   | Interface_mtu of int                    (* code 26 *)
   | All_subnets_local of bool               (* code 27 *)
   | Broadcast_addr of Ipaddr_sexp.V4.t           (* code 28 *)
-  | Perform_mask_discovery of bool          (* code 29 *)
-  | Mask_supplier of bool                   (* code 30 *)
   | Perform_router_disc of bool             (* code 31 *)
   | Router_sol_addr of Ipaddr_sexp.V4.t          (* code 32 *)
   | Static_routes of (Ipaddr_sexp.V4.t * Ipaddr_sexp.V4.t) list (* code 33 *)
@@ -726,7 +485,6 @@ type dhcp_option =
   | Ethernet_encapsulation of bool          (* code 36 *)
   | Tcp_default_ttl of int                  (* code 37 *)
   | Tcp_keepalive_interval of int32         (* code 38 *)
-  | Tcp_keepalive_garbage of int            (* code 39 *)
   | Nis_domain of string                    (* code 40 *)
   | Nis_servers of Ipaddr_sexp.V4.t list         (* code 41 *)
   | Ntp_servers of Ipaddr_sexp.V4.t list         (* code 42 *)
@@ -749,8 +507,6 @@ type dhcp_option =
   | Rebinding_t2 of int32                   (* code 59 *)
   | Vendor_class_id of string               (* code 60 *)
   | Client_id of client_id                  (* code 61 *)
-  | Netware_ip_domain of string             (* code 62 *)
-  | Netware_ip_option of string             (* code 63 *)
   | Nis_plus_domain of string               (* code 64 *)
   | Nis_plus_servers of Ipaddr_sexp.V4.t list    (* code 65 *)
   | Tftp_server_name of string              (* code 66 *)
@@ -759,87 +515,23 @@ type dhcp_option =
   | Smtp_servers of Ipaddr_sexp.V4.t list        (* code 69 *)
   | Pop3_servers of Ipaddr_sexp.V4.t list        (* code 70 *)
   | Nntp_servers of Ipaddr_sexp.V4.t list        (* code 71 *)
-  | Www_servers of Ipaddr_sexp.V4.t list         (* code 72 *)
-  | Finger_servers of Ipaddr_sexp.V4.t list      (* code 73 *)
   | Irc_servers of Ipaddr_sexp.V4.t list         (* code 74 *)
-  | Streettalk_servers of Ipaddr_sexp.V4.t list  (* code 75 *)
-  | Streettalk_da of Ipaddr_sexp.V4.t list  (* code 76 *)
   | User_class of string                    (* code 77 *)
-  | Directory_agent of string               (* code 78 *)
-  | Service_scope of string                 (* code 79 *)
   | Rapid_commit                            (* code 80 *)
   | Client_fqdn of string                   (* code 81 *)
   | Relay_agent_information of string       (* code 82 *)
-  | Isns of string                          (* code 83 *)
-  | Nds_servers of string                   (* code 85 *)
-  | Nds_tree_name of string                 (* code 86 *)
-  | Nds_context of string                   (* code 87 *)
-  | Bcmcs_controller_domain_name_list of string (* code 88 *)
-  | Bcmcs_controller_ipv4_addrs of Ipaddr_sexp.V4.t list (* code 89 *)
-  | Authentication of string                (* code 90 *)
-  | Client_last_transaction_time of int32   (* code 91 *)
-  | Associated_ips of Ipaddr_sexp.V4.t list (* code 92 *)
   | Client_system of string                 (* code 93 *)
   | Client_ndi of string                    (* code 94 *)
-  | Ldap of string                          (* code 95 *)
   | Uuid_guid of string                     (* code 97 *)
-  | User_auth of string                     (* code 98 *)
-  | Geoconf_civic of string                 (* code 99 *)
   | Pcode of string                         (* code 100 *)
   | Tcode of string                         (* code 101 *)
-  | Netinfo_address of string               (* code 112 *)
-  | Netinfo_tag of string                   (* code 113 *)
-  | Url of string                           (* code 114 *)
-  | Auto_config of int                      (* code 116 *)
-  | Name_service_search of string           (* code 117 *)
+  | IPv6_only of int32                      (* code 108 *)
   | Subnet_selection of Ipaddr_sexp.V4.t    (* code 118 *)
   | Domain_search of string                 (* code 119 *)
   | Sip_servers of string                   (* code 120 *)
   | Classless_static_route of string        (* code 121 *) (* XXX current, use better type *)
-  | Ccc of string                           (* code 122 *)
-  | Geoconf of string                       (* code 123 *)
-  | Vi_vendor_class of string               (* code 124 *)
   | Vi_vendor_info of string                (* code 125 *)
-  | Pxe_128 of string                       (* code 128 *)
-  | Pxe_129 of string                       (* code 129 *)
-  | Pxe_130 of string                       (* code 130 *)
-  | Pxe_131 of string                       (* code 131 *)
-  | Pxe_132 of string                       (* code 132 *)
-  | Pxe_133 of string                       (* code 133 *)
-  | Pxe_134 of string                       (* code 134 *)
-  | Pxe_135 of string                       (* code 135 *)
-  | Pana_agent of string                    (* code 136 *)
-  | V4_lost of string                       (* code 137 *)
-  | Capwap_ac_v4 of string                  (* code 138 *)
-  | Ipv4_address_mos of string              (* code 139 *)
-  | Ipv4_fqdn_mos of string                 (* code 140 *)
-  | Sip_ua_domains of string                (* code 141 *)
-  | Ipv4_address_andsf of string            (* code 142 *)
-  | Geolock of string                       (* code 144 *)
-  | Forcenew_nonce_capable of string        (* code 145 *)
-  | Rdnss_selection of string               (* code 146 *)
   | Misc_150 of string                      (* code 150 *)
-  | Status_code of string                   (* code 151 *)
-  | Absolute_time of int32                  (* code 152 *)
-  | Start_time_of_state of int32            (* code 153 *)
-  | Query_start_time of int32               (* code 154 *)
-  | Query_end_time of int32                 (* code 155 *)
-  | Dhcp_state of int                       (* code 156 *)
-  | Data_source of int                      (* code 157 *)
-  | V4_pcp_server of string                 (* code 158 *)
-  | V4_portparams of string                 (* code 159 *)
-  | Dhcp_captive_portal of string           (* code 160 *)
-  | Etherboot_175 of string                 (* code 175 *)
-  | Ip_telefone of string                   (* code 176 *)
-  | Etherboot_177 of string                 (* code 177 *)
-  | Pxe_linux of int32                      (* code 208 *)
-  | Configuration_file of string            (* code 209 *)
-  | Path_prefix of string                   (* code 210 *)
-  | Reboot_time of int32                    (* code 211 *)
-  | Option_6rd of string                    (* code 212 *)
-  | V4_access_domain of string              (* code 213 *) (* XXX current, better parsing *)
-  | Subnet_allocation of int                (* code 220 *)
-  | Virtual_subnet_selection of string      (* code 221 *)
   | Private_classless_static_route of string(* code 249 *) (* XXX current, use better type *)
   | Web_proxy_auto_disc of string           (* code 252 *)
   | End                                     (* code 255 *)
@@ -907,15 +599,6 @@ let options_of_buf buf buf_len =
       in
       let get_16 () = if len <> 2 then invalid_arg bad_len else
           Cstruct.BE.get_uint16 body 0 in
-      let get_16_list ?(min_len=2) () =
-        let rec loop offset shorts =
-          if offset = len then shorts else
-            let short = Cstruct.BE.get_uint16 body offset in
-            loop (offset + 2) (short :: shorts)
-        in
-        if ((len mod 2) <> 0) || len < min_len then invalid_arg bad_len else
-          List.rev (loop 0 [])
-      in
       let get_32 () = if len <> 4 then invalid_arg bad_len else
           Cstruct.BE.get_uint32 body 0 in
       let get_32_list ?(min_len=4) () =
@@ -969,17 +652,11 @@ let options_of_buf buf buf_len =
       | 1 ->   take (Subnet_mask (get_ip ()))
       | 2 ->   take (Time_offset (get_32 ()))
       | 3 ->   take (Routers (get_ip_list ()))
-      | 4 ->   take (Time_servers (get_ip_list ()))
-      | 5 ->   take (Name_servers (get_ip_list ()))
       | 6 ->   take (Dns_servers (get_ip_list ()))
       | 7 ->   take (Log_servers (get_ip_list ()))
-      | 8 ->   take (Cookie_servers (get_ip_list ()))
       | 9 ->   take (Lpr_servers (get_ip_list ()))
-      | 10 ->  take (Impress_servers (get_ip_list ()))
-      | 11 ->  take (Rsclocation_servers (get_ip_list ()))
       | 12 ->  take (Hostname (get_string ()))
       | 13 ->  take (Bootfile_size (get_16 ()))
-      | 14 ->  take (Merit_dumpfile (get_string ()))
       | 15 ->  take (Domain_name (get_string ()))
       | 16 ->  take (Swap_server (get_ip ()))
       | 17 ->  take (Root_path (get_string ()))
@@ -989,13 +666,9 @@ let options_of_buf buf buf_len =
       | 21 ->  take (Policy_filters (get_prefix_list ()))
       | 22 ->  take (Max_datagram (get_16 ()))
       | 23 ->  take (Default_ip_ttl (get_8 ()))
-      | 24 ->  take (Pmtu_ageing_timo (get_32 ()))
-      | 25 ->  take (Pmtu_plateau_table (get_16_list ()))
       | 26 ->  take (Interface_mtu (get_16 ()))
       | 27 ->  take (All_subnets_local (get_bool ()))
       | 28 ->  take (Broadcast_addr (get_ip ()))
-      | 29 ->  take (Perform_mask_discovery (get_bool ()))
-      | 30 ->  take (Mask_supplier (get_bool ()))
       | 31 ->  take (Perform_router_disc (get_bool ()))
       | 32 ->  take (Router_sol_addr (get_ip ()))
       | 33 ->  take (Static_routes (get_ip_tuple_list ()))
@@ -1004,7 +677,6 @@ let options_of_buf buf buf_len =
       | 36 ->  take (Ethernet_encapsulation (get_bool ()))
       | 37 ->  take (Tcp_default_ttl (get_8 ()))
       | 38 ->  take (Tcp_keepalive_interval (get_32 ()))
-      | 39 ->  take (Tcp_keepalive_garbage (get_8 ()))
       | 40 ->  take (Nis_domain (get_string ()))
       | 41 ->  take (Nis_servers (get_ip_list ()))
       | 42 ->  take (Ntp_servers (get_ip_list ()))
@@ -1029,8 +701,6 @@ let options_of_buf buf buf_len =
       | 59 ->  take (Rebinding_t2 (get_32 ()))
       | 60 ->  take (Vendor_class_id (get_string ()))
       | 61 ->  take (Client_id (get_client_id ()))
-      | 62 ->  take (Netware_ip_domain (get_string ()))
-      | 63 ->  take (Netware_ip_option (get_string ()))
       | 64 ->  take (Nis_plus_domain (get_string ()))
       | 65 ->  take (Nis_plus_servers (get_ip_list ()))
       | 66 ->  take (Tftp_server_name (get_string ()))
@@ -1039,88 +709,25 @@ let options_of_buf buf buf_len =
       | 69 ->  take (Smtp_servers (get_ip_list ()))
       | 70 ->  take (Pop3_servers (get_ip_list ()))
       | 71 ->  take (Nntp_servers (get_ip_list ()))
-      | 72 ->  take (Www_servers (get_ip_list ()))
-      | 73 ->  take (Finger_servers (get_ip_list ()))
       | 74 ->  take (Irc_servers (get_ip_list ()))
-      | 75 ->  take (Streettalk_servers (get_ip_list ()))
-      | 76 ->  take (Streettalk_da (get_ip_list ()))
       | 77 ->  take (User_class (get_string ()))
-      | 78 ->  take (Directory_agent (get_string ()))
-      | 79 ->  take (Service_scope (get_string ()))
       | 80 ->  take Rapid_commit
       | 81 ->  take (Client_fqdn (get_string ()))
       | 82 ->  take (Relay_agent_information (get_string ()))
-      | 83 ->  take (Isns (get_string ()))
-      | 85 ->  take (Nds_servers (get_string ()))
-      | 86 ->  take (Nds_tree_name (get_string ()))
-      | 87 ->  take (Nds_context (get_string ()))
-      | 88 ->  take (Bcmcs_controller_domain_name_list (get_string ()))
-      | 89 ->  take (Bcmcs_controller_ipv4_addrs (get_ip_list ()))
-      | 90 ->  take (Authentication (get_string ()))
-      | 91 ->  take (Client_last_transaction_time (get_32 ()))
-      | 92 ->  take (Associated_ips (get_ip_list ()))
       | 93 ->  take (Client_system (get_string ()))
       | 94 ->  take (Client_ndi (get_string ()))
-      | 95 ->  take (Ldap (get_string ()))
       | 97 ->  take (Uuid_guid (get_string ()))
-      | 98 ->  take (User_auth (get_string ()))
-      | 99 ->  take (Geoconf_civic (get_string ()))
       | 100 -> take (Pcode (get_string ()))
       | 101 -> take (Tcode (get_string ()))
-      | 112 -> take (Netinfo_address (get_string ()))
-      | 113 -> take (Netinfo_tag (get_string ()))
-      | 114 -> take (Url (get_string ()))
-      | 116 -> take (Auto_config (get_8 ()))
-      | 117 -> take (Name_service_search (get_string ()))
+      | 108 -> take (IPv6_only (get_32 ()))
       | 118 -> take (Subnet_selection (get_ip ()))
       | 119 -> take (Domain_search (get_string ()))
       | 120 -> take (Sip_servers (get_string ()))
       | 121 -> take (Classless_static_route (get_string ()))
-      | 122 -> take (Ccc (get_string ()))
-      | 123 -> take (Geoconf (get_string ()))
-      | 124 -> take (Vi_vendor_class (get_string ()))
       | 125 -> take (Vi_vendor_info (get_string ()))
-      | 128 -> take (Pxe_128 (get_string ()))
-      | 129 -> take (Pxe_129 (get_string ()))
-      | 130 -> take (Pxe_130 (get_string ()))
-      | 131 -> take (Pxe_131 (get_string ()))
-      | 132 -> take (Pxe_132 (get_string ()))
-      | 133 -> take (Pxe_133 (get_string ()))
-      | 134 -> take (Pxe_134 (get_string ()))
-      | 135 -> take (Pxe_135 (get_string ()))
-      | 136 -> take (Pana_agent (get_string ()))
-      | 137 -> take (V4_lost (get_string ()))
-      | 138 -> take (Capwap_ac_v4 (get_string ()))
-      | 139 -> take (Ipv4_address_mos (get_string ()))
-      | 140 -> take (Ipv4_fqdn_mos (get_string ()))
-      | 141 -> take (Sip_ua_domains (get_string ()))
-      | 142 -> take (Ipv4_address_andsf (get_string ()))
-      | 144 -> take (Geolock (get_string ()))
-      | 145 -> take (Forcenew_nonce_capable (get_string ()))
-      | 146 -> take (Rdnss_selection (get_string ()))
       | 150 -> take (Misc_150 (get_string ()))
-      | 151 -> take (Status_code (get_string ()))
-      | 152 -> take (Absolute_time (get_32 ()))
-      | 153 -> take (Start_time_of_state (get_32 ()))
-      | 154 -> take (Query_start_time (get_32 ()))
-      | 155 -> take (Query_end_time (get_32 ()))
-      | 156 -> take (Dhcp_state (get_8 ()))
-      | 157 -> take (Data_source (get_8 ()))
-      | 158 -> take (V4_pcp_server (get_string ()))
-      | 159 -> take (V4_portparams (get_string ()))
-      | 160 -> take (Dhcp_captive_portal (get_string ()))
-      | 175 -> take (Etherboot_175 (get_string ()))
-      | 176 -> take (Ip_telefone (get_string ()))
-      | 177 -> take (Etherboot_177 (get_string ()))
-      | 208 -> take (Pxe_linux (get_32 ()))
-      | 209 -> take (Configuration_file (get_string ()))
-      | 210 -> take (Path_prefix (get_string ()))
-      | 211 -> take (Reboot_time (get_32 ()))
-      | 212 -> take (Option_6rd (get_string ()))
-      | 213 -> take (V4_access_domain (get_string ()))
-      | 220 -> take (Subnet_allocation (get_8 ()))
-      | 221 -> take (Virtual_subnet_selection (get_string ()))
-      | 252->  take (Web_proxy_auto_disc (get_string ()))
+      | 249 -> take (Private_classless_static_route (get_string ()))
+      | 252 -> take (Web_proxy_auto_disc (get_string ()))
       | _code -> discard ()
   in
   (* Extends options if it finds an Option_overload *)
@@ -1203,8 +810,6 @@ let buf_of_options sbuf options =
   in
   let put_coded_8_list ?min_len =
     make_listf ?min_len (fun buf x -> put_8 x buf) 1 in
-  let put_coded_16_list ?min_len =
-    make_listf ?min_len (fun buf x -> put_16 x buf) 2 in
   (* let put_coded_32_list = make_listf (fun buf x -> put_32 x buf) 4 in *)
   let put_coded_ip_list ?min_len =
     make_listf ?min_len (fun buf x -> put_ip x buf) 4 in
@@ -1218,17 +823,11 @@ let buf_of_options sbuf options =
     | Subnet_mask mask -> put_coded_ip 1 mask buf             (* code 1 *)
     | Time_offset toff -> put_coded_32 2 toff buf             (* code 2 *)
     | Routers ips -> put_coded_ip_list 3 ips buf              (* code 3 *)
-    | Time_servers ips -> put_coded_ip_list 4 ips buf         (* code 4 *)
-    | Name_servers ips -> put_coded_ip_list 5 ips buf         (* code 5 *)
     | Dns_servers ips -> put_coded_ip_list 6 ips buf          (* code 6 *)
     | Log_servers ips -> put_coded_ip_list 7 ips buf          (* code 7 *)
-    | Cookie_servers ips -> put_coded_ip_list 8 ips buf       (* code 8 *)
     | Lpr_servers ips -> put_coded_ip_list 9 ips buf          (* code 9 *)
-    | Impress_servers ips -> put_coded_ip_list 10 ips buf     (* code 10 *)
-    | Rsclocation_servers ips -> put_coded_ip_list 11 ips buf (* code 11 *)
     | Hostname h -> put_coded_bytes 12 h buf                  (* code 12 *)
     | Bootfile_size bs -> put_coded_16 13 bs buf              (* code 13 *)
-    | Merit_dumpfile md -> put_coded_bytes 14 md buf          (* code 14 *)
     | Domain_name dn -> put_coded_bytes 15 dn buf             (* code 15 *)
     | Swap_server ss -> put_coded_ip 16 ss buf                (* code 16 *)
     | Root_path rp -> put_coded_bytes 17 rp buf               (* code 17 *)
@@ -1238,13 +837,9 @@ let buf_of_options sbuf options =
     | Policy_filters pf -> put_coded_prefix_list 21 pf buf    (* code 21 *)
     | Max_datagram md -> put_coded_16 22 md buf               (* code 22 *)
     | Default_ip_ttl dit -> put_coded_8 23 dit buf            (* code 23 *)
-    | Pmtu_ageing_timo pat -> put_coded_32 24 pat buf         (* code 24 *)
-    | Pmtu_plateau_table ppt -> put_coded_16_list 25 ppt buf  (* code 25 *)
     | Interface_mtu im -> put_coded_16 26 im buf              (* code 26 *)
     | All_subnets_local b -> put_coded_bool 27 b buf          (* code 27 *)
     | Broadcast_addr ba -> put_coded_ip 28 ba buf             (* code 28 *)
-    | Perform_mask_discovery b -> put_coded_bool 29 b buf     (* code 29 *)
-    | Mask_supplier b -> put_coded_bool 30 b buf              (* code 30 *)
     | Perform_router_disc b -> put_coded_bool 31 b buf        (* code 31 *)
     | Router_sol_addr rsa -> put_coded_ip 32 rsa buf          (* code 32 *)
     | Static_routes srs -> put_coded_ip_tuple_list 33 srs buf (* code 33 *)
@@ -1253,7 +848,6 @@ let buf_of_options sbuf options =
     | Ethernet_encapsulation b -> put_coded_bool 36 b buf     (* code 36 *)
     | Tcp_default_ttl tdt -> put_coded_8 37 tdt buf           (* code 37 *)
     | Tcp_keepalive_interval tki -> put_coded_32 38 tki buf   (* code 38 *)
-    | Tcp_keepalive_garbage tkg -> put_coded_8 39 tkg buf     (* code 39 *)
     | Nis_domain nd -> put_coded_bytes 40 nd buf              (* code 40 *)
     | Nis_servers ips -> put_coded_ip_list 41 ips buf         (* code 41 *)
     | Ntp_servers ips -> put_coded_ip_list 42 ips buf         (* code 42 *)
@@ -1278,8 +872,6 @@ let buf_of_options sbuf options =
     | Rebinding_t2 rt -> put_coded_32 59 rt buf               (* code 59 *)
     | Vendor_class_id vci -> put_coded_bytes 60 vci buf       (* code 60 *)
     | Client_id id -> put_client_id 61 id buf                 (* code 61 *)
-    | Netware_ip_domain d -> put_coded_bytes 62 d buf         (* code 62 *)
-    | Netware_ip_option o -> put_coded_bytes 63 o buf         (* code 63 *)
     | Nis_plus_domain npd -> put_coded_bytes 64 npd buf       (* code 64 *)
     | Nis_plus_servers ips -> put_coded_ip_list 65 ips buf    (* code 65 *)
     | Tftp_server_name tsn -> put_coded_bytes 66 tsn buf      (* code 66 *)
@@ -1288,89 +880,25 @@ let buf_of_options sbuf options =
     | Smtp_servers ips -> put_coded_ip_list 69 ips buf        (* code 69 *)
     | Pop3_servers ips -> put_coded_ip_list 70 ips buf        (* code 70 *)
     | Nntp_servers ips -> put_coded_ip_list 71 ips buf        (* code 71 *)
-    | Www_servers ips -> put_coded_ip_list 72 ips buf         (* code 72 *)
-    | Finger_servers ips -> put_coded_ip_list 73 ips buf      (* code 73 *)
     | Irc_servers ips -> put_coded_ip_list 74 ips buf         (* code 74 *)
-    | Streettalk_servers ips -> put_coded_ip_list 75 ips buf  (* code 75 *)
-    | Streettalk_da ips -> put_coded_ip_list 76 ips buf       (* code 76 *)
     | User_class uc -> put_coded_bytes 77 uc buf              (* code 77 *)
-    | Directory_agent da -> put_coded_bytes 78 da buf         (* code 78 *)
-    | Service_scope ss -> put_coded_bytes 79 ss buf           (* code 79 *)
     | Rapid_commit -> put_coded_bytes 80 "" buf               (* code 80 *)
     | Client_fqdn dn -> put_coded_bytes 81 dn buf             (* code 81 *)
     | Relay_agent_information ai -> put_coded_bytes 82 ai buf (* code 82 *)
-    | Isns i -> put_coded_bytes 83 i buf                      (* code 83 *)
-    | Nds_servers ns -> put_coded_bytes 85 ns buf             (* code 85 *)
-    | Nds_tree_name nn -> put_coded_bytes 86 nn buf           (* code 86 *)
-    | Nds_context nc -> put_coded_bytes 87 nc buf             (* code 87 *)
-    | Bcmcs_controller_domain_name_list l -> put_coded_bytes 88 l buf (* code 88 *)
-    | Bcmcs_controller_ipv4_addrs l -> put_coded_ip_list 89 l buf (* code 89 *)
-    | Authentication a -> put_coded_bytes 90 a buf            (* code 90 *)
-    | Client_last_transaction_time t -> put_coded_32 91 t buf (* code 91 *)
-    | Associated_ips l -> put_coded_ip_list 92 l buf          (* code 92 *)
     | Client_system cs -> put_coded_bytes 93 cs buf           (* code 93 *)
     | Client_ndi ndi -> put_coded_bytes 94 ndi buf            (* code 94 *)
-    | Ldap ldap -> put_coded_bytes 95 ldap buf                (* code 95 *)
     | Uuid_guid u -> put_coded_bytes 97 u buf                 (* code 97 *)
-    | User_auth u -> put_coded_bytes 98 u buf                 (* code 98 *)
-    | Geoconf_civic gc -> put_coded_bytes 99 gc buf           (* code 99 *)
     | Pcode p -> put_coded_bytes 100 p buf                    (* code 100 *)
     | Tcode t -> put_coded_bytes 101 t buf                    (* code 101 *)
-    | Netinfo_address na -> put_coded_bytes 112 na buf        (* code 112 *)
-    | Netinfo_tag nt -> put_coded_bytes 113 nt buf            (* code 113 *)
-    | Url u -> put_coded_bytes 114 u buf                      (* code 114 *)
-    | Auto_config ac -> put_coded_8 116 ac buf                (* code 116 *)
-    | Name_service_search nss -> put_coded_bytes 117 nss buf  (* code 117 *)
+    | IPv6_only ts -> put_coded_32 108 ts buf                 (* code 108 *)
     | Subnet_selection ip -> put_coded_ip 118 ip buf          (* code 118 *)
     | Domain_search s -> put_coded_bytes 119 s buf            (* code 119 *)
     | Sip_servers ss -> put_coded_bytes 120 ss buf            (* code 120 *)
     | Classless_static_route r -> put_coded_bytes 121 r buf   (* code 121 *) (* XXX current, use better type *)
-    | Ccc c -> put_coded_bytes 122 c buf                      (* code 122 *)
-    | Geoconf g -> put_coded_bytes 123 g buf                  (* code 123 *)
-    | Vi_vendor_class vc -> put_coded_bytes 124 vc buf        (* code 124 *)
     | Vi_vendor_info vi -> put_coded_bytes 125 vi buf         (* code 125 *)
-    | Pxe_128 p -> put_coded_bytes 128 p buf                  (* code 128 *)
-    | Pxe_129 p -> put_coded_bytes 129 p buf                  (* code 129 *)
-    | Pxe_130 p -> put_coded_bytes 130 p buf                  (* code 130 *)
-    | Pxe_131 p -> put_coded_bytes 131 p buf                  (* code 131 *)
-    | Pxe_132 p -> put_coded_bytes 132 p buf                  (* code 132 *)
-    | Pxe_133 p -> put_coded_bytes 133 p buf                  (* code 133 *)
-    | Pxe_134 p -> put_coded_bytes 134 p buf                  (* code 134 *)
-    | Pxe_135 p -> put_coded_bytes 135 p buf                  (* code 135 *)
-    | Pana_agent pa -> put_coded_bytes 136 pa buf             (* code 136 *)
-    | V4_lost v -> put_coded_bytes 137 v buf                  (* code 137 *)
-    | Capwap_ac_v4 c -> put_coded_bytes 138 c buf             (* code 138 *)
-    | Ipv4_address_mos m -> put_coded_bytes 139 m buf         (* code 139 *)
-    | Ipv4_fqdn_mos m -> put_coded_bytes 140 m buf            (* code 140 *)
-    | Sip_ua_domains d -> put_coded_bytes 141 d buf           (* code 141 *)
-    | Ipv4_address_andsf a -> put_coded_bytes 142 a buf       (* code 142 *)
-    | Geolock s -> put_coded_bytes 144 s buf                  (* code 144 *)
-    | Forcenew_nonce_capable s -> put_coded_bytes 145 s buf   (* code 145 *)
-    | Rdnss_selection s -> put_coded_bytes 146 s buf          (* code 146 *)
     | Misc_150 s -> put_coded_bytes 150 s buf                 (* code 150 *)
-    | Status_code s -> put_coded_bytes 151 s buf              (* code 151 *)
-    | Absolute_time t -> put_coded_32 152 t buf               (* code 152 *)
-    | Start_time_of_state t -> put_coded_32 153 t buf         (* code 153 *)
-    | Query_start_time t -> put_coded_32 154 t buf            (* code 154 *)
-    | Query_end_time t -> put_coded_32 155 t buf              (* code 155 *)
-    | Dhcp_state s -> put_coded_8 156 s buf                   (* code 156 *) (* octet *)
-    | Data_source s -> put_coded_8 157 s buf                  (* code 157 *) (* octet *)
-    | V4_pcp_server s -> put_coded_bytes 158 s buf            (* code 158 *)
-    | V4_portparams s -> put_coded_bytes 159 s buf            (* code 159 *)
-    | Dhcp_captive_portal s -> put_coded_bytes 160 s buf      (* code 160 *)
-    | Etherboot_175 s -> put_coded_bytes 175 s buf            (* code 175 *)
-    | Ip_telefone s -> put_coded_bytes 176 s buf              (* code 176 *)
-    | Etherboot_177 s -> put_coded_bytes 177 s buf            (* code 177 *)
-    | Pxe_linux w -> put_coded_32 208 w buf                   (* code 208 *)
-    | Configuration_file s -> put_coded_bytes 209 s buf       (* code 209 *)
-    | Path_prefix s -> put_coded_bytes 210 s buf              (* code 210 *)
-    | Reboot_time t -> put_coded_32 211 t buf                 (* code 211 *)
-    | Option_6rd s -> put_coded_bytes 212 s buf               (* code 212 *)
-    | V4_access_domain s -> put_coded_bytes 213 s buf         (* code 213 *) (* XXX current, better parsing *)
-    | Subnet_allocation b -> put_coded_8 220 b buf            (* code 220 *) (* octet *)
-    | Virtual_subnet_selection s -> put_coded_bytes 221 s buf (* code 221 *)
-    | Private_classless_static_route r -> put_coded_bytes 249 r buf(* code 249 *) (* XXX current, use better type *)
-    | Web_proxy_auto_disc wpad -> put_coded_bytes 252 wpad buf(* code 252 *)
+    | Private_classless_static_route r -> put_coded_bytes 249 r buf (* code 249 *) (* XXX current, use better type *)
+    | Web_proxy_auto_disc wpad -> put_coded_bytes 252 wpad buf (* code 252 *)
     | Unassigned (code, s) -> put_coded_bytes code s buf (* unassigned *)
     | End -> buf (* discard, we add ourselves *)              (* code 255 *)
   in
@@ -1575,28 +1103,16 @@ let find_time_offset =
   find_option (function Time_offset x -> Some x | _ -> None)
 let collect_routers =
   collect_options (function Routers x -> Some x | _ -> None)
-let collect_time_servers =
-  collect_options (function Time_servers x -> Some x | _ -> None)
-let collect_name_servers =
-  collect_options (function Name_servers x -> Some x | _ -> None)
 let collect_dns_servers =
   collect_options (function Dns_servers x -> Some x | _ -> None)
 let collect_log_servers =
   collect_options (function Log_servers x -> Some x | _ -> None)
-let collect_cookie_servers =
-  collect_options (function Cookie_servers x -> Some x | _ -> None)
 let collect_lpr_servers =
   collect_options (function Lpr_servers x -> Some x | _ -> None)
-let collect_impress_servers =
-  collect_options (function Impress_servers x -> Some x | _ -> None)
-let collect_rsc_location_servers =
-  collect_options (function Rsclocation_servers x -> Some x | _ -> None)
 let find_hostname =
   find_option (function Hostname x -> Some x | _ -> None)
 let find_bootfile_size =
   find_option (function Bootfile_size x -> Some x | _ -> None)
-let find_merit_dumpfile =
-  find_option (function Merit_dumpfile x -> Some x | _ -> None)
 let find_domain_name =
   find_option (function Domain_name x -> Some x | _ -> None)
 let find_swap_server =
@@ -1615,20 +1131,12 @@ let find_max_datagram =
   find_option (function Max_datagram x -> Some x | _ -> None)
 let find_default_ip_ttl =
   find_option (function Default_ip_ttl x -> Some x | _ -> None)
-let find_pmtu_ageing_timo =
-  find_option (function Pmtu_ageing_timo x -> Some x | _ -> None)
-let find_pmtu_plateau_table =
-  find_option (function Pmtu_plateau_table x -> Some x | _ -> None)
 let find_interface_mtu =
   find_option (function Interface_mtu x -> Some x | _ -> None)
 let find_all_subnets_local =
   find_option (function All_subnets_local x -> Some x | _ -> None)
 let find_broadcast_addr =
   find_option (function Broadcast_addr x -> Some x | _ -> None)
-let find_perform_mask_discovery =
-  find_option (function Perform_mask_discovery x -> Some x | _ -> None)
-let find_mask_supplier =
-  find_option (function Mask_supplier x -> Some x | _ -> None)
 let find_perform_router_disc =
   find_option (function Perform_router_disc x -> Some x | _ -> None)
 let find_router_sol_addr =
@@ -1645,8 +1153,6 @@ let find_tcp_default_ttl =
   find_option (function Tcp_default_ttl x -> Some x | _ -> None)
 let find_tcp_keepalive_interval =
   find_option (function Tcp_keepalive_interval x -> Some x | _ -> None)
-let find_tcp_keepalive_garbage =
-  find_option (function Tcp_keepalive_garbage x -> Some x | _ -> None)
 let find_nis_domain =
   find_option (function Nis_domain x -> Some x | _ -> None)
 let collect_nis_servers =
@@ -1691,10 +1197,6 @@ let find_vendor_class_id =
   find_option (function Vendor_class_id x -> Some x | _ -> None)
 let find_client_id =
   find_option (function Client_id x -> Some x | _ -> None)
-let find_netware_ip_domain =
-  find_option (function Netware_ip_domain x -> Some x | _ -> None)
-let find_netware_ip_option =
-  find_option (function Netware_ip_option x -> Some x | _ -> None)
 let find_nis_plus_domain =
   find_option (function Nis_plus_domain x -> Some x | _ -> None)
 let collect_nis_plus_servers =
@@ -1711,72 +1213,28 @@ let collect_pop3_servers =
   collect_options (function Pop3_servers x -> Some x | _ -> None)
 let collect_nntp_servers =
   collect_options (function Nntp_servers x -> Some x | _ -> None)
-let collect_www_servers =
-  collect_options (function Www_servers x -> Some x | _ -> None)
-let collect_finger_servers =
-  collect_options (function Finger_servers x -> Some x | _ -> None)
 let collect_irc_servers =
   collect_options (function Irc_servers x -> Some x | _ -> None)
-let collect_streettalk_servers =
-  collect_options (function Streettalk_servers x -> Some x | _ -> None)
-let collect_streettalk_da =
-  collect_options (function Streettalk_da x -> Some x | _ -> None)
 let find_user_class =
   find_option (function User_class x -> Some x | _ -> None)
-let find_directory_agent =
-  find_option (function Directory_agent x -> Some x | _ -> None)
-let find_service_scope =
-  find_option (function Service_scope x -> Some x | _ -> None)
 let find_rapid_commit =
   find_option (function Rapid_commit -> Some Rapid_commit | _ -> None)
 let find_client_fqdn =
   find_option (function Client_fqdn x -> Some x | _ -> None)
 let find_relay_agent_information =
   find_option (function Relay_agent_information x -> Some x | _ -> None)
-let find_isns =
-  find_option (function Isns x -> Some x | _ -> None)
-let find_nds_servers=
-  find_option (function Nds_servers x -> Some x | _ -> None)
-let find_nds_tree_name =
-  find_option (function Nds_tree_name x -> Some x | _ -> None)
-let find_nds_context =
-  find_option (function Nds_context x -> Some x | _ -> None)
-let find_bcmcs_controller_domain_name =
-  find_option (function Bcmcs_controller_domain_name_list x -> Some x | _ -> None)
-let collect_bcmcs_controller_ipv4_addrs =
-  collect_options (function Bcmcs_controller_ipv4_addrs x -> Some x | _ -> None)
-let find_authentication =
-  find_option (function Authentication x -> Some x | _ -> None)
-let find_client_last_transaction_time =
-  find_option (function Client_last_transaction_time x -> Some x | _ -> None)
-let collect_associated_ips =
-  collect_options (function Associated_ips x -> Some x | _ -> None)
 let find_client_system =
   find_option (function Client_system x -> Some x | _ -> None)
 let find_client_ndi =
   find_option (function Client_ndi x -> Some x | _ -> None)
-let find_ldap =
-  find_option (function Ldap x -> Some x | _ -> None)
 let find_uuid_guid =
   find_option (function Uuid_guid x -> Some x | _ -> None)
-let find_user_auth =
-  find_option (function User_auth x -> Some x | _ -> None)
-let find_geoconf_civic =
-  find_option (function Geoconf_civic x -> Some x | _ -> None)
 let find_pcode =
   find_option (function Pcode x -> Some x | _ -> None)
 let find_tcode =
   find_option (function Tcode x -> Some x | _ -> None)
-let find_netinfo_address =
-  find_option (function Netinfo_address x -> Some x | _ -> None)
-let find_netinfo_tag =
-  find_option (function Netinfo_tag x -> Some x | _ -> None)
-let find_url =
-  find_option (function Url x -> Some x | _ -> None)
-let find_auto_config =
-  find_option (function Auto_config x -> Some x | _ -> None)
-let find_name_service_search =
-  find_option (function Name_service_search x -> Some x | _ -> None)
+let find_ipv6only =
+  find_option (function IPv6_only x -> Some x | _ -> None)
 let find_subnet_selection =
   find_option (function Subnet_selection x -> Some x | _ -> None)
 let find_domain_search =
@@ -1785,99 +1243,15 @@ let find_sip_servers =
   find_option (function Sip_servers x -> Some x | _ -> None)
 let find_classless_static_route =
   find_option (function Classless_static_route x -> Some x | _ -> None)
-let find_ccc =
-  find_option (function Ccc x -> Some x | _ -> None)
-let find_geoconf =
-  find_option (function Geoconf x -> Some x | _ -> None)
-let find_vi_vendor_class =
-  find_option (function Vi_vendor_class x -> Some x | _ -> None)
 let find_vi_vendor_info =
   find_option (function Vi_vendor_info x -> Some x | _ -> None)
-let find_pxe_128 =
-  find_option (function Pxe_128 x -> Some x | _ -> None)
-let find_pxe_129 =
-  find_option (function Pxe_129 x -> Some x | _ -> None)
-let find_pxe_130 =
-  find_option (function Pxe_130 x -> Some x | _ -> None)
-let find_pxe_131 =
-  find_option (function Pxe_131 x -> Some x | _ -> None)
-let find_pxe_132 =
-  find_option (function Pxe_132 x -> Some x | _ -> None)
-let find_pxe_133 =
-  find_option (function Pxe_133 x -> Some x | _ -> None)
-let find_pxe_134 =
-  find_option (function Pxe_134 x -> Some x | _ -> None)
-let find_pxe_135 =
-  find_option (function Pxe_135 x -> Some x | _ -> None)
-let find_pana_agent =
-  find_option (function Pana_agent x -> Some x | _ -> None)
-let find_v4_lost =
-  find_option (function V4_lost x -> Some x | _ -> None)
-let find_capwap_ac_v4 =
-  find_option (function Capwap_ac_v4 x -> Some x | _ -> None)
-let find_ipv4_address_mos =
-  find_option (function Ipv4_address_mos x -> Some x | _ -> None)
-let find_ipv4_fqdn_mos =
-  find_option (function Ipv4_fqdn_mos x -> Some x | _ -> None)
-let find_sip_ua_domains =
-  find_option (function Sip_ua_domains x -> Some x | _ -> None)
-let find_ipv4_address_andsf =
-  find_option (function Ipv4_address_andsf x -> Some x | _ -> None)
-let find_geolock =
-  find_option (function Geolock x -> Some x | _ -> None)
-let find_forcenew_nonce_capable =
-  find_option (function Forcenew_nonce_capable x -> Some x | _ -> None)
-let find_rdnss_selection =
-  find_option (function Rdnss_selection x -> Some x | _ -> None)
 let find_misc_150 =
   find_option (function Misc_150 x -> Some x | _ -> None)
-let find_status_code =
-  find_option (function Status_code x -> Some x | _ -> None)
-let find_absolute_time =
-  find_option (function Absolute_time x -> Some x | _ -> None)
-let find_start_time_of_state =
-  find_option (function Start_time_of_state x -> Some x | _ -> None)
-let find_query_start_time =
-  find_option (function Query_start_time x -> Some x | _ -> None)
-let find_query_end_time =
-  find_option (function Query_end_time x -> Some x | _ -> None)
-let find_dhcp_state =
-  find_option (function Dhcp_state x -> Some x | _ -> None)
-let find_data_source=
-  find_option (function Data_source x -> Some x | _ -> None)
-let find_v4_pcp_server =
-  find_option (function V4_pcp_server x -> Some x | _ -> None)
-let find_v4_portparams =
-  find_option (function V4_portparams x -> Some x | _ -> None)
-let find_dhcp_captive_portal =
-  find_option (function Dhcp_captive_portal x -> Some x | _ -> None)
-let find_etherboot_175 =
-  find_option (function Etherboot_175 x -> Some x | _ -> None)
-let find_ip_telefone =
-  find_option (function Ip_telefone x -> Some x | _ -> None)
-let find_etherboot_177 =
-  find_option (function Etherboot_177 x -> Some x | _ -> None)
-let find_pxe_linux =
-  find_option (function Pxe_linux x -> Some x | _ -> None)
-let find_configuration_file =
-  find_option (function Configuration_file x -> Some x | _ -> None)
-let find_path_prefix =
-  find_option (function Path_prefix x -> Some x | _ -> None)
-let find_reboot_time =
-  find_option (function Reboot_time x -> Some x | _ -> None)
-let find_option_6rd =
-  find_option (function Option_6rd x -> Some x | _ -> None)
-let find_v4_access_domain =
-  find_option (function V4_access_domain x -> Some x | _ -> None)
-let find_subnet_allocation =
-  find_option (function Subnet_allocation x -> Some x | _ -> None)
-let find_virtual_subnet_selection =
-  find_option (function Virtual_subnet_selection x -> Some x | _ -> None)
 let find_web_proxy_auto_disc =
   find_option (function Web_proxy_auto_disc x -> Some x | _ -> None)
+let find_private_classless_static_route =
+  find_option (function Private_classless_static_route x -> Some x | _ -> None)
 let find_unassigned code =
   find_option (function Unassigned (c, s) when c = code -> Some (c, s) | _ -> None)
 let collect_unassigned code =
   collect_options (function Unassigned (c, s) when c = code -> Some [(c, s)] | _ -> None)
-let find_private_classless_static_route =
-  find_option (function Private_classless_static_route x -> Some x | _ -> None)

--- a/lib/dhcp_wire.ml
+++ b/lib/dhcp_wire.ml
@@ -275,7 +275,7 @@ type option_code =
   | PRIVATE_CLASSLESS_STATIC_ROUTE [@id 249]
   | WEB_PROXY_AUTO_DISC [@id 252]
   | END [@id 255]
-  | UNKNOWN of int [@@deriving sexp]
+  | OTHER of int [@@deriving sexp]
 
 let int_to_option_code = function
   | 0 -> Some PAD
@@ -357,7 +357,7 @@ let int_to_option_code = function
   | 249 -> Some PRIVATE_CLASSLESS_STATIC_ROUTE
   | 252 -> Some WEB_PROXY_AUTO_DISC
   | 255 -> Some END
-  | x -> Some (UNKNOWN x)
+  | x -> Some (OTHER x)
 
 let int_to_option_code_exn v = Option.get (int_to_option_code v)
 
@@ -441,7 +441,7 @@ let option_code_to_int = function
   | PRIVATE_CLASSLESS_STATIC_ROUTE -> 249
   | WEB_PROXY_AUTO_DISC -> 252
   | END -> 255
-  | UNKNOWN x -> x
+  | OTHER x -> x
 
 type htype =
   | Ethernet_10mb
@@ -535,7 +535,7 @@ type dhcp_option =
   | Private_classless_static_route of string(* code 249 *) (* XXX current, use better type *)
   | Web_proxy_auto_disc of string           (* code 252 *)
   | End                                     (* code 255 *)
-  | Unassigned of int * string              (* code * string *)
+  | Other of int * string              (* code * string *)
   [@@deriving sexp]
 
 type pkt = {
@@ -899,7 +899,7 @@ let buf_of_options sbuf options =
     | Misc_150 s -> put_coded_bytes 150 s buf                 (* code 150 *)
     | Private_classless_static_route r -> put_coded_bytes 249 r buf (* code 249 *) (* XXX current, use better type *)
     | Web_proxy_auto_disc wpad -> put_coded_bytes 252 wpad buf (* code 252 *)
-    | Unassigned (code, s) -> put_coded_bytes code s buf (* unassigned *)
+    | Other (code, s) -> put_coded_bytes code s buf (* unassigned *)
     | End -> buf (* discard, we add ourselves *)              (* code 255 *)
   in
   match options with
@@ -1251,7 +1251,7 @@ let find_web_proxy_auto_disc =
   find_option (function Web_proxy_auto_disc x -> Some x | _ -> None)
 let find_private_classless_static_route =
   find_option (function Private_classless_static_route x -> Some x | _ -> None)
-let find_unassigned code =
-  find_option (function Unassigned (c, s) when c = code -> Some (c, s) | _ -> None)
-let collect_unassigned code =
-  collect_options (function Unassigned (c, s) when c = code -> Some [(c, s)] | _ -> None)
+let find_other code =
+  find_option (function Other (c, s) when c = code -> Some (c, s) | _ -> None)
+let collect_other code =
+  collect_options (function Other (c, s) when c = code -> Some [(c, s)] | _ -> None)

--- a/lib/dhcp_wire.ml
+++ b/lib/dhcp_wire.ml
@@ -15,9 +15,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Sexplib.Conv
-open Sexplib.Std
-
 let ( let* ) = Result.bind
 
 let guard p e = if p then Result.Ok () else Result.Error e
@@ -127,7 +124,10 @@ let sizeof_dhcp = 236
 type op =
   | BOOTREQUEST (* 1 *)
   | BOOTREPLY   (* 2 *)
-[@@deriving sexp]
+
+let op_to_string = function
+  | BOOTREQUEST -> "BOOT REQUEST"
+  | BOOTREPLY -> "BOOT REPLY"
 
 let int_to_op = function
   | 1 -> Some BOOTREQUEST
@@ -156,7 +156,23 @@ type msgtype =
   | DHCPLEASEACTIVE
   | DHCPBULKLEASEQUERY
   | DHCPLEASEQUERYDONE
-[@@deriving sexp]
+
+let msgtype_to_string = function
+  | DHCPDISCOVER -> "DHCP DISCOVER"
+  | DHCPOFFER -> "DHCP OFFER"
+  | DHCPREQUEST -> "DHCP REQUEST"
+  | DHCPDECLINE -> "DHCP DECLINE"
+  | DHCPACK -> "DHCP ACK"
+  | DHCPNAK -> "DHCP NAK"
+  | DHCPRELEASE -> "DHCP RELEASE"
+  | DHCPINFORM -> "DHCP INFORM"
+  | DHCPFORCERENEW -> "DHCP FORCE RENEW"
+  | DHCPLEASEQUERY -> "DHCP LEASE QUERY"
+  | DHCPLEASEUNASSIGNED -> "DHCP LEASE UNASSIGNED"
+  | DHCPLEASEUNKNOWN -> "DHCP LEASE UNKNOWN"
+  | DHCPLEASEACTIVE -> "DHCP LEASE ACTIVE"
+  | DHCPBULKLEASEQUERY -> "DHCP BULK LEASE QUERY"
+  | DHCPLEASEQUERYDONE -> "DHCP LEASE QUERY DONE"
 
 let int_to_msgtype = function
   | 1 -> Some DHCPDISCOVER
@@ -275,7 +291,89 @@ type option_code =
   | PRIVATE_CLASSLESS_STATIC_ROUTE [@id 249]
   | WEB_PROXY_AUTO_DISC [@id 252]
   | END [@id 255]
-  | OTHER of int [@@deriving sexp]
+  | OTHER of int
+
+let option_code_to_string = function
+  | PAD -> "PAD"
+  | SUBNET_MASK -> "Subnet mask"
+  | TIME_OFFSET -> "Time offset"
+  | ROUTERS -> "Routers"
+  | DNS_SERVERS -> "DNS servers"
+  | LOG_SERVERS -> "Log servers"
+  | LPR_SERVERS -> "LPR servers"
+  | HOSTNAME -> "Hostname"
+  | BOOTFILE_SIZE -> "Bootfile size"
+  | DOMAIN_NAME -> "Domain name"
+  | SWAP_SERVER -> "Swap server"
+  | ROOT_PATH -> "Root path"
+  | EXTENSION_PATH -> "Extension path"
+  | IPFORWARDING -> "IP forwarding"
+  | NLSR -> "NLSR"
+  | POLICY_FILTERS -> "Policy filters"
+  | MAX_DATAGRAM -> "Max datagram"
+  | DEFAULT_IP_TTL -> "Default IP TTL"
+  | INTERFACE_MTU -> "Interface MTU"
+  | ALL_SUBNETS_LOCAL -> "All subnets local"
+  | BROADCAST_ADDR -> "Broadcast address"
+  | PERFORM_ROUTER_DISC -> "Perform router discovery"
+  | ROUTER_SOL_ADDR -> "Router solicitation address"
+  | STATIC_ROUTES -> "Static routes"
+  | TRAILER_ENCAPSULATION -> "Trailer encapsulation"
+  | ARP_CACHE_TIMO -> "ARP cache timeout"
+  | ETHERNET_ENCAPSULATION -> "Ethernet encapsulation"
+  | TCP_DEFAULT_TTL -> "TCP default TTL"
+  | TCP_KEEPALIVE_INTERVAL -> "TCP keep-alive interval"
+  | NIS_DOMAIN -> "NIS domain"
+  | NIS_SERVERS -> "NIS servers"
+  | NTP_SERVERS -> "NTP servers"
+  | VENDOR_SPECIFIC -> "Vendor specific"
+  | NETBIOS_NAME_SERVERS -> "NETBIOS name servers"
+  | NETBIOS_DATAGRAM_DISTRIB_SERVERS -> "NETBIOS datagram distribution servers"
+  | NETBIOS_NODE -> "NETBIOS node"
+  | NETBIOS_SCOPE -> "NETBIOS scope"
+  | XWINDOW_FONT_SERVERS -> "X window font servers"
+  | XWINDOW_DISPLAY_MANAGERS -> "X window display managers"
+  | REQUEST_IP -> "Request IP"
+  | IP_LEASE_TIME -> "IP lease time"
+  | OPTION_OVERLOAD -> "Option overload"
+  | MESSAGE_TYPE -> "Message type"
+  | SERVER_IDENTIFIER -> "Server identifier"
+  | PARAMETER_REQUESTS -> "Parameters requests"
+  | MESSAGE -> "Message"
+  | MAX_MESSAGE -> "Max message"
+  | RENEWAL_T1 -> "Renewal T1"
+  | REBINDING_T2 -> "Rebinding T2"
+  | VENDOR_CLASS_ID -> "Vendor class ID"
+  | CLIENT_ID -> "Client ID"
+  | NIS_PLUS_DOMAIN -> "NIS+ domain"
+  | NIS_PLUS_SERVERS -> "NIS+ servers"
+  | TFTP_SERVER_NAME -> "TFTP server name"
+  | BOOTFILE_NAME -> "Bootfile name"
+  | MOBILE_IP_HOME_AGENT -> "Mobile IP home agent"
+  | SMTP_SERVERS -> "SMTP servers"
+  | POP3_SERVERS -> "POP3 servers"
+  | NNTP_SERVERS -> "NNTP servers"
+  | IRC_SERVERS -> "IRC servers"
+  | USER_CLASS -> "User class"
+  | RAPID_COMMIT -> "Rapid commit"
+  | CLIENT_FQDN -> "Client FQDN"
+  | RELAY_AGENT_INFORMATION -> "Relay agent information"
+  | CLIENT_SYSTEM -> "Client system"
+  | CLIENT_NDI -> "Client NDI"
+  | UUID_GUID -> "UUID GUID"
+  | PCODE -> "PCODE"
+  | TCODE -> "TCODE"
+  | IPV6ONLY -> "IPv6 only"
+  | SUBNET_SELECTION -> "Subnet selection"
+  | DOMAIN_SEARCH -> "Domain search"
+  | SIP_SERVERS -> "SIP servers"
+  | CLASSLESS_STATIC_ROUTE -> "Classless static route"
+  | VI_VENDOR_INFO -> "VI vendor info"
+  | MISC_150 -> "Misc 150"
+  | PRIVATE_CLASSLESS_STATIC_ROUTE -> "Private classless static route"
+  | WEB_PROXY_AUTO_DISC -> "Web proxy auto discovery"
+  | END -> "End"
+  | OTHER id -> "Other " ^ string_of_int id
 
 let int_to_option_code = function
   | 0 -> Some PAD
@@ -445,61 +543,87 @@ let option_code_to_int = function
 
 type htype =
   | Ethernet_10mb
-  | Other [@@deriving sexp]
+  | Other
+
+let htype_to_string = function
+  | Ethernet_10mb -> "Ethernet 10MB"
+  | Other -> "Other"
 
 type flags =
   | Broadcast
-  | Unicast [@@deriving sexp]
+  | Unicast
+
+let flags_to_string = function
+  | Broadcast -> "Broadcast"
+  | Unicast -> "Unicast"
 
 type client_id =
-  | Hwaddr of Macaddr_sexp.t
-  | Id of int * string [@@deriving sexp]
+  | Hwaddr of Macaddr.t
+  | Id of int * string
+
+let client_id_to_string = function
+  | Hwaddr mac -> "MAC " ^ Macaddr.to_string mac
+  | Id (id, txt) -> "ID " ^ string_of_int id ^ " " ^ Ohex.encode txt
+
+let string_to_client_id = function
+  | s when String.starts_with ~prefix:"MAC " s ->
+    Result.to_option
+      (Result.map (fun mac -> Hwaddr mac)
+         (Macaddr.of_string (String.sub s 4 (String.length s - 4))))
+  | s when String.starts_with ~prefix:"ID " s ->
+    (match String.split_on_char ' ' s with
+     | [ _id ; id ; txt ]->
+       (match int_of_string_opt id with
+        | None -> None
+        | Some id -> Some (Id (id, Ohex.decode txt)))
+     | _ -> None)
+  | _ -> None
 
 type dhcp_option =
   | Pad                                     (* code 0 *)
-  | Subnet_mask of Ipaddr_sexp.V4.t         (* code 1 *)
+  | Subnet_mask of Ipaddr.V4.t         (* code 1 *)
   | Time_offset of int32                    (* code 2 *)
-  | Routers of Ipaddr_sexp.V4.t list        (* code 3 *)
-  | Dns_servers of Ipaddr_sexp.V4.t list         (* code 6 *)
-  | Log_servers of Ipaddr_sexp.V4.t list         (* code 7 *)
-  | Lpr_servers of Ipaddr_sexp.V4.t list         (* code 9 *)
+  | Routers of Ipaddr.V4.t list        (* code 3 *)
+  | Dns_servers of Ipaddr.V4.t list         (* code 6 *)
+  | Log_servers of Ipaddr.V4.t list         (* code 7 *)
+  | Lpr_servers of Ipaddr.V4.t list         (* code 9 *)
   | Hostname of string                      (* code 12 *)
   | Bootfile_size of int                    (* code 13 *)
   | Domain_name of string                   (* code 15 *)
-  | Swap_server of Ipaddr_sexp.V4.t              (* code 16 *)
+  | Swap_server of Ipaddr.V4.t              (* code 16 *)
   | Root_path of string                     (* code 17 *)
   | Extension_path of string                (* code 18 *)
   | Ipforwarding of bool                    (* code 19 *)
   | Nlsr of bool                            (* code 20 *)
-  | Policy_filters of Ipaddr_sexp.V4.Prefix.t list (* code 21 *)
+  | Policy_filters of Ipaddr.V4.Prefix.t list (* code 21 *)
   | Max_datagram of int                     (* code 22 *)
   | Default_ip_ttl of int                   (* code 23 *)
   | Interface_mtu of int                    (* code 26 *)
   | All_subnets_local of bool               (* code 27 *)
-  | Broadcast_addr of Ipaddr_sexp.V4.t           (* code 28 *)
+  | Broadcast_addr of Ipaddr.V4.t           (* code 28 *)
   | Perform_router_disc of bool             (* code 31 *)
-  | Router_sol_addr of Ipaddr_sexp.V4.t          (* code 32 *)
-  | Static_routes of (Ipaddr_sexp.V4.t * Ipaddr_sexp.V4.t) list (* code 33 *)
+  | Router_sol_addr of Ipaddr.V4.t          (* code 32 *)
+  | Static_routes of (Ipaddr.V4.t * Ipaddr.V4.t) list (* code 33 *)
   | Trailer_encapsulation of bool           (* code 34 *)
   | Arp_cache_timo of int32                 (* code 35 *)
   | Ethernet_encapsulation of bool          (* code 36 *)
   | Tcp_default_ttl of int                  (* code 37 *)
   | Tcp_keepalive_interval of int32         (* code 38 *)
   | Nis_domain of string                    (* code 40 *)
-  | Nis_servers of Ipaddr_sexp.V4.t list         (* code 41 *)
-  | Ntp_servers of Ipaddr_sexp.V4.t list         (* code 42 *)
+  | Nis_servers of Ipaddr.V4.t list         (* code 41 *)
+  | Ntp_servers of Ipaddr.V4.t list         (* code 42 *)
   | Vendor_specific of string               (* code 43 *)
-  | Netbios_name_servers of Ipaddr_sexp.V4.t list(* code 44 *)
-  | Netbios_datagram_distrib_servers of Ipaddr_sexp.V4.t list (* code 45 *)
+  | Netbios_name_servers of Ipaddr.V4.t list(* code 44 *)
+  | Netbios_datagram_distrib_servers of Ipaddr.V4.t list (* code 45 *)
   | Netbios_node of int                     (* code 46 *)
   | Netbios_scope of string                 (* code 47 *)
-  | Xwindow_font_servers of Ipaddr_sexp.V4.t list(* code 48 *)
-  | Xwindow_display_managers of Ipaddr_sexp.V4.t list (* code 49 *)
-  | Request_ip of Ipaddr_sexp.V4.t               (* code 50 *)
+  | Xwindow_font_servers of Ipaddr.V4.t list(* code 48 *)
+  | Xwindow_display_managers of Ipaddr.V4.t list (* code 49 *)
+  | Request_ip of Ipaddr.V4.t               (* code 50 *)
   | Ip_lease_time of int32                  (* code 51 *)
   | Option_overload of int                  (* code 52 *)
   | Message_type of msgtype                 (* code 53 *)
-  | Server_identifier of Ipaddr_sexp.V4.t        (* code 54 *)
+  | Server_identifier of Ipaddr.V4.t        (* code 54 *)
   | Parameter_requests of option_code list  (* code 55 *)
   | Message of string                       (* code 56 *)
   | Max_message of int                      (* code 57 *)
@@ -508,14 +632,14 @@ type dhcp_option =
   | Vendor_class_id of string               (* code 60 *)
   | Client_id of client_id                  (* code 61 *)
   | Nis_plus_domain of string               (* code 64 *)
-  | Nis_plus_servers of Ipaddr_sexp.V4.t list    (* code 65 *)
+  | Nis_plus_servers of Ipaddr.V4.t list    (* code 65 *)
   | Tftp_server_name of string              (* code 66 *)
   | Bootfile_name of string                 (* code 67 *)
-  | Mobile_ip_home_agent of Ipaddr_sexp.V4.t list(* code 68 *)
-  | Smtp_servers of Ipaddr_sexp.V4.t list        (* code 69 *)
-  | Pop3_servers of Ipaddr_sexp.V4.t list        (* code 70 *)
-  | Nntp_servers of Ipaddr_sexp.V4.t list        (* code 71 *)
-  | Irc_servers of Ipaddr_sexp.V4.t list         (* code 74 *)
+  | Mobile_ip_home_agent of Ipaddr.V4.t list(* code 68 *)
+  | Smtp_servers of Ipaddr.V4.t list        (* code 69 *)
+  | Pop3_servers of Ipaddr.V4.t list        (* code 70 *)
+  | Nntp_servers of Ipaddr.V4.t list        (* code 71 *)
+  | Irc_servers of Ipaddr.V4.t list         (* code 74 *)
   | User_class of string                    (* code 77 *)
   | Rapid_commit                            (* code 80 *)
   | Client_fqdn of string                   (* code 81 *)
@@ -526,7 +650,7 @@ type dhcp_option =
   | Pcode of string                         (* code 100 *)
   | Tcode of string                         (* code 101 *)
   | IPv6_only of int32                      (* code 108 *)
-  | Subnet_selection of Ipaddr_sexp.V4.t    (* code 118 *)
+  | Subnet_selection of Ipaddr.V4.t    (* code 118 *)
   | Domain_search of string                 (* code 119 *)
   | Sip_servers of string                   (* code 120 *)
   | Classless_static_route of string        (* code 121 *) (* XXX current, use better type *)
@@ -536,13 +660,94 @@ type dhcp_option =
   | Web_proxy_auto_disc of string           (* code 252 *)
   | End                                     (* code 255 *)
   | Other of int * string              (* code * string *)
-  [@@deriving sexp]
+
+let dhcp_option_to_string = function
+  | Pad -> "Pad"
+  | Subnet_mask ip -> "Subnet mask " ^ Ipaddr.V4.to_string ip
+  | Time_offset off -> "Time offset " ^ Int32.to_string off
+  | Routers ips -> "Routers " ^ String.concat ", " (List.map Ipaddr.V4.to_string ips)
+  | Dns_servers ips -> "DNS servers " ^ String.concat ", " (List.map Ipaddr.V4.to_string ips)
+  | Log_servers ips -> "Log servers " ^ String.concat ", " (List.map Ipaddr.V4.to_string ips)
+  | Lpr_servers ips -> "LPR servers " ^ String.concat ", " (List.map Ipaddr.V4.to_string ips)
+  | Hostname s -> "Hostname " ^ s
+  | Bootfile_size s -> "Bootfile size " ^ string_of_int s
+  | Domain_name s -> "Domain name " ^ s
+  | Swap_server ip -> "Swap server " ^ Ipaddr.V4.to_string ip
+  | Root_path s -> "Root path " ^ s
+  | Extension_path s -> "Extension path " ^ s
+  | Ipforwarding b -> "IP forwarding " ^ string_of_bool b
+  | Nlsr b -> "NLSR " ^ string_of_bool b
+  | Policy_filters f -> "Policy filters " ^ String.concat ", " (List.map Ipaddr.V4.Prefix.to_string f)
+  | Max_datagram s -> "Max datagram " ^ string_of_int s
+  | Default_ip_ttl s -> "Default IP TTL " ^ string_of_int s
+  | Interface_mtu s -> "Interface MTU " ^ string_of_int s
+  | All_subnets_local b -> "All subnets local " ^ string_of_bool b
+  | Broadcast_addr ip -> "Broadcast address " ^ Ipaddr.V4.to_string ip
+  | Perform_router_disc b -> "Perform router discovery " ^ string_of_bool b
+  | Router_sol_addr ip -> "Router solicitation address " ^ Ipaddr.V4.to_string ip
+  | Static_routes routes -> "Static routes " ^ String.concat ", " (List.map (fun (a, b) -> Ipaddr.V4.to_string a ^ " -> " ^ Ipaddr.V4.to_string b) routes)
+  | Trailer_encapsulation b -> "Trailer encapsulation " ^ string_of_bool b
+  | Arp_cache_timo t -> "ARP cache timeout " ^ Int32.to_string t
+  | Ethernet_encapsulation b -> "Ethernet encapsulation " ^ string_of_bool b
+  | Tcp_default_ttl t -> "TCP default TTL " ^ string_of_int t
+  | Tcp_keepalive_interval t -> "TCP keep-alive interval " ^ Int32.to_string t
+  | Nis_domain s -> "NIS domain " ^ s
+  | Nis_servers ips -> "NIS servers " ^ String.concat ", " (List.map Ipaddr.V4.to_string ips)
+  | Ntp_servers ips -> "NTP servers " ^ String.concat ", " (List.map Ipaddr.V4.to_string ips)
+  | Vendor_specific s -> "Vendor specific " ^ s
+  | Netbios_name_servers ips -> "NETBIOS name servers "  ^ String.concat ", " (List.map Ipaddr.V4.to_string ips)
+  | Netbios_datagram_distrib_servers ips -> "NETBIOS datagram distribution servers "  ^ String.concat ", " (List.map Ipaddr.V4.to_string ips)
+  | Netbios_node i -> "NETBIOS node " ^ string_of_int i
+  | Netbios_scope s -> "NETBIOS scope " ^ s
+  | Xwindow_font_servers ips -> "XWindow font servers " ^ String.concat ", " (List.map Ipaddr.V4.to_string ips)
+  | Xwindow_display_managers ips -> "Xwindow display managers " ^ String.concat ", " (List.map Ipaddr.V4.to_string ips)
+  | Request_ip ip -> "Request IP " ^ Ipaddr.V4.to_string ip
+  | Ip_lease_time i -> "IP lease time " ^ Int32.to_string i
+  | Option_overload i -> "Option overload " ^ string_of_int i
+  | Message_type t -> "Message type " ^ msgtype_to_string t
+  | Server_identifier ip -> "Server identifier " ^ Ipaddr.V4.to_string ip
+  | Parameter_requests ops -> "Parameter request " ^ String.concat ", " (List.map option_code_to_string ops)
+  | Message s -> "Message " ^ s
+  | Max_message i -> "Max message " ^ string_of_int i
+  | Renewal_t1 t -> "Renewal T1 " ^ Int32.to_string t
+  | Rebinding_t2 t -> "Rebinding T2 " ^ Int32.to_string t
+  | Vendor_class_id s -> "Vendor class ID " ^ s
+  | Client_id c -> "Client ID " ^ client_id_to_string c
+  | Nis_plus_domain s -> "NIS+ domain " ^ s
+  | Nis_plus_servers ips -> "NIS+ servers " ^ String.concat ", " (List.map Ipaddr.V4.to_string ips)
+  | Tftp_server_name s -> "TFTP server name " ^ s
+  | Bootfile_name s -> "Bootfile name " ^ s
+  | Mobile_ip_home_agent ips -> "Mobile IP home agent " ^ String.concat ", " (List.map Ipaddr.V4.to_string ips)
+  | Smtp_servers ips -> "SMTP servers " ^ String.concat ", " (List.map Ipaddr.V4.to_string ips)
+  | Pop3_servers ips -> "POP3 servers " ^ String.concat ", " (List.map Ipaddr.V4.to_string ips)
+  | Nntp_servers ips -> "NNTP servers " ^ String.concat ", " (List.map Ipaddr.V4.to_string ips)
+  | Irc_servers ips -> "IRC servers " ^ String.concat ", " (List.map Ipaddr.V4.to_string ips)
+  | User_class s -> "User class " ^ s
+  | Rapid_commit -> "Rapid commit"
+  | Client_fqdn s -> "Client FQDN " ^ s
+  | Relay_agent_information s -> "Relay agent information " ^ s
+  | Client_system s -> "Client system " ^ s
+  | Client_ndi s -> "Client NDI " ^ s
+  | Uuid_guid s -> "UUID GUID " ^ s
+  | Pcode s -> "PCODE " ^ s
+  | Tcode s -> "TCODE " ^ s
+  | IPv6_only i -> "IPv6 only " ^ Int32.to_string i
+  | Subnet_selection ip -> "Subnet selection " ^ Ipaddr.V4.to_string ip
+  | Domain_search s -> "Domain search " ^ s
+  | Sip_servers s -> "SIP servers " ^ s
+  | Classless_static_route s -> "Classless static route " ^ s
+  | Vi_vendor_info s -> "VI vendor info " ^ s
+  | Misc_150 s -> "Misc 150 " ^ s
+  | Private_classless_static_route s -> "Private classless static route " ^ s
+  | Web_proxy_auto_disc s -> "Web proxy auto discovery " ^ s
+  | End -> "End"
+  | Other (id, s) -> "Other " ^ string_of_int id ^ ": " ^ s
 
 type pkt = {
-  srcmac  : Macaddr_sexp.t;
-  dstmac  : Macaddr_sexp.t;
-  srcip   : Ipaddr_sexp.V4.t;
-  dstip   : Ipaddr_sexp.V4.t;
+  srcmac  : Macaddr.t;
+  dstmac  : Macaddr.t;
+  srcip   : Ipaddr.V4.t;
+  dstip   : Ipaddr.V4.t;
   srcport : int;
   dstport : int;
   op      : op;
@@ -552,15 +757,22 @@ type pkt = {
   xid     : int32;
   secs    : int;
   flags   : flags;
-  ciaddr  : Ipaddr_sexp.V4.t;
-  yiaddr  : Ipaddr_sexp.V4.t;
-  siaddr  : Ipaddr_sexp.V4.t;
-  giaddr  : Ipaddr_sexp.V4.t;
-  chaddr  : Macaddr_sexp.t;
+  ciaddr  : Ipaddr.V4.t;
+  yiaddr  : Ipaddr.V4.t;
+  siaddr  : Ipaddr.V4.t;
+  giaddr  : Ipaddr.V4.t;
+  chaddr  : Macaddr.t;
   sname   : string;
   file    : string;
   options : dhcp_option list;
-} [@@deriving sexp]
+}
+
+let pp_pkt ppf pkt =
+  Fmt.pf ppf "src MAC %a dst MAC %a@.src IP %a dst IP %a@.src port %u dst port %u@.operation %s@.htype %s hlen %u hops %u@.XID %lu secs %u flags %s@.ciaddr %a yiaddr %a@.siaddr %a giaddr %a chaddr %a@.sname %s file %s@.options %a"
+    Macaddr.pp pkt.srcmac Macaddr.pp pkt.dstmac Ipaddr.V4.pp pkt.srcip Ipaddr.V4.pp pkt.dstip
+    pkt.srcport pkt.dstport (op_to_string pkt.op) (htype_to_string pkt.htype) pkt.hlen pkt.hops pkt.xid pkt.secs
+    (flags_to_string pkt.flags) Ipaddr.V4.pp pkt.ciaddr Ipaddr.V4.pp pkt.yiaddr Ipaddr.V4.pp pkt.siaddr Ipaddr.V4.pp pkt.giaddr Macaddr.pp pkt.chaddr pkt.sname pkt.file Fmt.(list ~sep:(any ", ") string) (List.map dhcp_option_to_string pkt.options)
+
 
 let client_port = 68
 let server_port = 67
@@ -1090,12 +1302,6 @@ let client_id_of_pkt pkt =
   with
   | Some id -> id
   | None -> Hwaddr pkt.chaddr
-
-(* string_of_* functions *)
-let to_hum f x = Sexplib.Sexp.to_string_hum (f x)
-let client_id_to_string = to_hum sexp_of_client_id
-let pkt_to_string = to_hum sexp_of_pkt
-let dhcp_option_to_string = to_hum sexp_of_dhcp_option
 
 let find_subnet_mask =
   find_option (function Subnet_mask x -> Some x | _ -> None)

--- a/lib/dhcp_wire.mli
+++ b/lib/dhcp_wire.mli
@@ -31,12 +31,12 @@ type op =
 (** Conversions of {! op}s. *)
 
 val int_to_op : int -> op option
-val int_to_op_exn : int -> op
-(** @raise Invalid_argument if [v < 0 || v > 255]  *)
+
+val int_to_op_exn : int -> op (** @raise Invalid_argument if [v < 0 || v > 255]  *)
+
 val op_to_int : op -> int
 
-val sexp_of_op : op -> Sexplib.Sexp.t
-val op_of_sexp : Sexplib.Sexp.t -> op
+val op_to_string : op -> string
 
 (** {2 DHCP message type option values} *)
 
@@ -64,8 +64,7 @@ val int_to_msgtype : int -> msgtype option
 val int_to_msgtype_exn : int -> msgtype
 (** @raise Invalid_argument if not a valid {! msgtype} value *)
 
-val sexp_of_msgtype : msgtype -> Sexplib.Sexp.t
-val msgtype_of_sexp : Sexplib.Sexp.t -> msgtype
+val msgtype_to_string : msgtype -> string
 
 (** {2 DHCP option codes (names only, for use in parameter requests)} *)
 
@@ -159,9 +158,7 @@ type option_code =
 val int_to_option_code : int -> option_code option
 val int_to_option_code_exn : int -> option_code
 val option_code_to_int : option_code -> int
-
-val sexp_of_option_code : option_code -> Sexplib.Sexp.t
-val option_code_of_sexp : Sexplib.Sexp.t -> option_code
+val option_code_to_string : option_code -> string
 
 (** {2 DHCP hardware type} *)
 
@@ -171,8 +168,7 @@ type htype =
 
 (** Conversions of {!htype}. *)
 
-val htype_of_sexp : Sexplib.Sexp.t -> htype
-val sexp_of_htype : htype -> Sexplib.Sexp.t
+val htype_to_string : htype -> string
 
 (** {2 DHCP header flags} *)
 
@@ -182,8 +178,7 @@ type flags =
 
 (** Conversions of {!flags}. *)
 
-val flags_of_sexp : Sexplib.Sexp.t -> flags
-val sexp_of_flags : flags -> Sexplib.Sexp.t
+val flags_to_string : flags -> string
 
 (** {2 DHCP Client identifier} *)
 
@@ -195,10 +190,8 @@ type client_id =
 
 (** Conversions of {! client_id}. *)
 
-val client_id_of_sexp : Sexplib.Sexp.t -> client_id
-val sexp_of_client_id : client_id -> Sexplib.Sexp.t
-
 val client_id_to_string : client_id -> string
+val string_to_client_id : string -> client_id option
 
 (** {2 DHCP options} *)
 
@@ -283,10 +276,11 @@ type dhcp_option =
   | Web_proxy_auto_disc of string           (* code 252 *)
   | End                                     (* code 255 *)
   | Other of int * string              (* int * string *)
-  [@@deriving sexp]
 (** Not all options are currently implemented. *)
 
 (** Conversions of {! dhcp_option}. *)
+
+val dhcp_option_to_string : dhcp_option -> string
 
 val buf_of_options : Cstruct.t -> dhcp_option list -> Cstruct.t
 val options_of_buf : Cstruct.t -> int -> dhcp_option list
@@ -299,11 +293,6 @@ val collect_options : ('a -> 'b list option) -> 'a list -> 'b list
 (** [collect_options f l] collects all options where [f] evaluates to [Some]
     value on list [l], this is useful for list options like [Routers], if
     multiple list options are found, the resulting list is flattened. *)
-
-val dhcp_option_of_sexp : Sexplib.Sexp.t -> dhcp_option
-val sexp_of_dhcp_option : dhcp_option -> Sexplib.Sexp.t
-
-val dhcp_option_to_string : dhcp_option -> string
 
 val collect_dns_servers : dhcp_option list -> Ipaddr.V4.t list
 val collect_irc_servers : dhcp_option list -> Ipaddr.V4.t list
@@ -417,11 +406,9 @@ val pkt_of_buf : Cstruct.t -> int -> (pkt, string) result
 val buf_of_pkt : pkt -> Cstruct.t
 val pkt_into_buf : pkt -> Cstruct.t -> int
 
-val pkt_of_sexp : Sexplib.Sexp.t -> pkt
-val sexp_of_pkt : pkt -> Sexplib.Sexp.t
+val pp_pkt : pkt Fmt.t
 
 val client_id_of_pkt : pkt -> client_id
-val pkt_to_string : pkt -> string
 
 (** Helpers. *)
 

--- a/lib/dhcp_wire.mli
+++ b/lib/dhcp_wire.mli
@@ -74,17 +74,11 @@ type option_code =
   | SUBNET_MASK
   | TIME_OFFSET
   | ROUTERS
-  | TIME_SERVERS
-  | NAME_SERVERS
   | DNS_SERVERS
   | LOG_SERVERS
-  | COOKIE_SERVERS
   | LPR_SERVERS
-  | IMPRESS_SERVERS
-  | RSCLOCATION_SERVERS
   | HOSTNAME
   | BOOTFILE_SIZE
-  | MERIT_DUMPFILE
   | DOMAIN_NAME
   | SWAP_SERVER
   | ROOT_PATH
@@ -94,13 +88,9 @@ type option_code =
   | POLICY_FILTERS
   | MAX_DATAGRAM
   | DEFAULT_IP_TTL
-  | PMTU_AGEING_TIMO
-  | PMTU_PLATEAU_TABLE
   | INTERFACE_MTU
   | ALL_SUBNETS_LOCAL
   | BROADCAST_ADDR
-  | PERFORM_MASK_DISCOVERY
-  | MASK_SUPPLIER
   | PERFORM_ROUTER_DISC
   | ROUTER_SOL_ADDR
   | STATIC_ROUTES
@@ -109,7 +99,6 @@ type option_code =
   | ETHERNET_ENCAPSULATION
   | TCP_DEFAULT_TTL
   | TCP_KEEPALIVE_INTERVAL
-  | TCP_KEEPALIVE_GARBAGE
   | NIS_DOMAIN
   | NIS_SERVERS
   | NTP_SERVERS
@@ -132,8 +121,6 @@ type option_code =
   | REBINDING_T2
   | VENDOR_CLASS_ID
   | CLIENT_ID
-  | NETWARE_IP_DOMAIN
-  | NETWARE_IP_OPTION
   | NIS_PLUS_DOMAIN
   | NIS_PLUS_SERVERS
   | TFTP_SERVER_NAME
@@ -142,87 +129,23 @@ type option_code =
   | SMTP_SERVERS
   | POP3_SERVERS
   | NNTP_SERVERS
-  | WWW_SERVERS
-  | FINGER_SERVERS
   | IRC_SERVERS
-  | STREETTALK_SERVERS
-  | STREETTALK_DA
   | USER_CLASS
-  | DIRECTORY_AGENT
-  | SERVICE_SCOPE
   | RAPID_COMMIT
   | CLIENT_FQDN
   | RELAY_AGENT_INFORMATION
-  | ISNS
-  | NDS_SERVERS
-  | NDS_TREE_NAME
-  | NDS_CONTEXT
-  | BCMCS_CONTROLLER_DOMAIN_NAME_LIST
-  | BCMCS_CONTROLLER_IPV4_ADDR
-  | AUTHENTICATION
-  | CLIENT_LAST_TRANSACTION_TIME
-  | ASSOCIATED_IPS
   | CLIENT_SYSTEM
   | CLIENT_NDI
-  | LDAP
   | UUID_GUID
-  | USER_AUTH
-  | GEOCONF_CIVIC
   | PCODE
   | TCODE
-  | NETINFO_ADDRESS
-  | NETINFO_TAG
-  | URL
-  | AUTO_CONFIG
-  | NAME_SERVICE_SEARCH
+  | IPV6ONLY
   | SUBNET_SELECTION
   | DOMAIN_SEARCH
   | SIP_SERVERS
   | CLASSLESS_STATIC_ROUTE
-  | CCC
-  | GEOCONF
-  | VI_VENDOR_CLASS
   | VI_VENDOR_INFO
-  | PXE_128
-  | PXE_129
-  | PXE_130
-  | PXE_131
-  | PXE_132
-  | PXE_133
-  | PXE_134
-  | PXE_135
-  | PANA_AGENT
-  | V4_LOST
-  | CAPWAP_AC_V4
-  | IPV4_ADDRESS_MOS
-  | IPV4_FQDN_MOS
-  | SIP_UA_DOMAINS
-  | IPV4_ADDRESS_ANDSF
-  | GEOLOCK
-  | FORCENEW_NONCE_CAPABLE
-  | RDNSS_SELECTION
   | MISC_150
-  | STATUS_CODE
-  | ABSOLUTE_TIME
-  | START_TIME_OF_STATE
-  | QUERY_START_TIME
-  | QUERY_END_TIME
-  | DHCP_STATE
-  | DATA_SOURCE
-  | V4_PCP_SERVER
-  | V4_PORTPARAMS
-  | DHCP_CAPTIVE_PORTAL
-  | ETHERBOOT_175
-  | IP_TELEFONE
-  | ETHERBOOT_177
-  | PXE_LINUX
-  | CONFIGURATION_FILE
-  | PATH_PREFIX
-  | REBOOT_TIME
-  | OPTION_6RD
-  | V4_ACCESS_DOMAIN
-  | SUBNET_ALLOCATION
-  | VIRTUAL_SUBNET_SELECTION
   | PRIVATE_CLASSLESS_STATIC_ROUTE
   | WEB_PROXY_AUTO_DISC
   | END
@@ -284,17 +207,11 @@ type dhcp_option =
   | Subnet_mask of Ipaddr.V4.t              (* code 1 *)
   | Time_offset of int32                    (* code 2 *)
   | Routers of Ipaddr.V4.t list             (* code 3 *)
-  | Time_servers of Ipaddr.V4.t list        (* code 4 *)
-  | Name_servers of Ipaddr.V4.t list        (* code 5 *)
   | Dns_servers of Ipaddr.V4.t list         (* code 6 *)
   | Log_servers of Ipaddr.V4.t list         (* code 7 *)
-  | Cookie_servers of Ipaddr.V4.t list      (* code 8 *)
   | Lpr_servers of Ipaddr.V4.t list         (* code 9 *)
-  | Impress_servers of Ipaddr.V4.t list     (* code 10 *)
-  | Rsclocation_servers of Ipaddr.V4.t list (* code 11 *)
   | Hostname of string                      (* code 12 *)
   | Bootfile_size of int                    (* code 13 *)
-  | Merit_dumpfile of string                (* code 14 *)
   | Domain_name of string                   (* code 15 *)
   | Swap_server of Ipaddr.V4.t              (* code 16 *)
   | Root_path of string                     (* code 17 *)
@@ -304,13 +221,9 @@ type dhcp_option =
   | Policy_filters of Ipaddr.V4.Prefix.t list (* code 21 *)
   | Max_datagram of int                     (* code 22 *)
   | Default_ip_ttl of int                   (* code 23 *)
-  | Pmtu_ageing_timo of int32               (* code 24 *)
-  | Pmtu_plateau_table of int list          (* code 25 *)
   | Interface_mtu of int                    (* code 26 *)
   | All_subnets_local of bool               (* code 27 *)
   | Broadcast_addr of Ipaddr.V4.t           (* code 28 *)
-  | Perform_mask_discovery of bool          (* code 29 *)
-  | Mask_supplier of bool                   (* code 30 *)
   | Perform_router_disc of bool             (* code 31 *)
   | Router_sol_addr of Ipaddr.V4.t          (* code 32 *)
   | Static_routes of (Ipaddr.V4.t * Ipaddr.V4.t) list (* code 33 *)
@@ -319,7 +232,6 @@ type dhcp_option =
   | Ethernet_encapsulation of bool          (* code 36 *)
   | Tcp_default_ttl of int                  (* code 37 *)
   | Tcp_keepalive_interval of int32         (* code 38 *)
-  | Tcp_keepalive_garbage of int            (* code 39 *)
   | Nis_domain of string                    (* code 40 *)
   | Nis_servers of Ipaddr.V4.t list         (* code 41 *)
   | Ntp_servers of Ipaddr.V4.t list         (* code 42 *)
@@ -342,8 +254,6 @@ type dhcp_option =
   | Rebinding_t2 of int32                   (* code 59 *)
   | Vendor_class_id of string               (* code 60 *)
   | Client_id of client_id                  (* code 61 *)
-  | Netware_ip_domain of string             (* code 62 *)
-  | Netware_ip_option of string             (* code 63 *)
   | Nis_plus_domain of string               (* code 64 *)
   | Nis_plus_servers of Ipaddr.V4.t list    (* code 65 *)
   | Tftp_server_name of string              (* code 66 *)
@@ -352,87 +262,23 @@ type dhcp_option =
   | Smtp_servers of Ipaddr.V4.t list        (* code 69 *)
   | Pop3_servers of Ipaddr.V4.t list        (* code 70 *)
   | Nntp_servers of Ipaddr.V4.t list        (* code 71 *)
-  | Www_servers of Ipaddr.V4.t list         (* code 72 *)
-  | Finger_servers of Ipaddr.V4.t list      (* code 73 *)
   | Irc_servers of Ipaddr.V4.t list         (* code 74 *)
-  | Streettalk_servers of Ipaddr.V4.t list  (* code 75 *)
-  | Streettalk_da of Ipaddr.V4.t list       (* code 76 *)
   | User_class of string                    (* code 77 *)
-  | Directory_agent of string               (* code 78 *)
-  | Service_scope of string                 (* code 79 *)
   | Rapid_commit                            (* code 80 *)
   | Client_fqdn of string                   (* code 81 *)
   | Relay_agent_information of string       (* code 82 *)
-  | Isns of string                          (* code 83 *)
-  | Nds_servers of string                   (* code 85 *)
-  | Nds_tree_name of string                 (* code 86 *)
-  | Nds_context of string                   (* code 87 *)
-  | Bcmcs_controller_domain_name_list of string (* code 88 *)
-  | Bcmcs_controller_ipv4_addrs of Ipaddr.V4.t list (* code 89 *)
-  | Authentication of string                (* code 90 *)
-  | Client_last_transaction_time of int32   (* code 91 *)
-  | Associated_ips of Ipaddr.V4.t list       (* code 92 *)
   | Client_system of string                 (* code 93 *)
   | Client_ndi of string                    (* code 94 *)
-  | Ldap of string                          (* code 95 *)
   | Uuid_guid of string                     (* code 97 *)
-  | User_auth of string                     (* code 98 *)
-  | Geoconf_civic of string                 (* code 99 *)
   | Pcode of string                         (* code 100 *)
   | Tcode of string                         (* code 101 *)
-  | Netinfo_address of string               (* code 112 *)
-  | Netinfo_tag of string                   (* code 113 *)
-  | Url of string                           (* code 114 *)
-  | Auto_config of int                      (* code 116 *)
-  | Name_service_search of string           (* code 117 *)
+  | IPv6_only of int32                      (* code 108 *)
   | Subnet_selection of Ipaddr.V4.t         (* code 118 *)
   | Domain_search of string                 (* code 119 *)
   | Sip_servers of string                   (* code 120 *)
   | Classless_static_route of string        (* code 121 *) (* XXX current, use better type *)
-  | Ccc of string                           (* code 122 *)
-  | Geoconf of string                       (* code 123 *)
-  | Vi_vendor_class of string               (* code 124 *)
   | Vi_vendor_info of string                (* code 125 *)
-  | Pxe_128 of string                       (* code 128 *)
-  | Pxe_129 of string                       (* code 129 *)
-  | Pxe_130 of string                       (* code 130 *)
-  | Pxe_131 of string                       (* code 131 *)
-  | Pxe_132 of string                       (* code 132 *)
-  | Pxe_133 of string                       (* code 133 *)
-  | Pxe_134 of string                       (* code 134 *)
-  | Pxe_135 of string                       (* code 135 *)
-  | Pana_agent of string                    (* code 136 *)
-  | V4_lost of string                       (* code 137 *)
-  | Capwap_ac_v4 of string                  (* code 138 *)
-  | Ipv4_address_mos of string              (* code 139 *)
-  | Ipv4_fqdn_mos of string                 (* code 140 *)
-  | Sip_ua_domains of string                (* code 141 *)
-  | Ipv4_address_andsf of string            (* code 142 *)
-  | Geolock of string                       (* code 144 *)
-  | Forcenew_nonce_capable of string        (* code 145 *)
-  | Rdnss_selection of string               (* code 146 *)
   | Misc_150 of string                      (* code 150 *)
-  | Status_code of string                   (* code 151 *)
-  | Absolute_time of int32                  (* code 152 *)
-  | Start_time_of_state of int32            (* code 153 *)
-  | Query_start_time of int32               (* code 154 *)
-  | Query_end_time of int32                 (* code 155 *)
-  | Dhcp_state of int                       (* code 156 *)
-  | Data_source of int                      (* code 157 *)
-  | V4_pcp_server of string                 (* code 158 *)
-  | V4_portparams of string                 (* code 159 *)
-  | Dhcp_captive_portal of string           (* code 160 *)
-  | Etherboot_175 of string                 (* code 175 *)
-  | Ip_telefone of string                   (* code 176 *)
-  | Etherboot_177 of string                 (* code 177 *)
-  | Pxe_linux of int32                      (* code 208 *)
-  | Configuration_file of string            (* code 209 *)
-  | Path_prefix of string                   (* code 210 *)
-  | Reboot_time of int32                    (* code 211 *)
-  | Option_6rd of string                    (* code 212 *)
-  | V4_access_domain of string              (* code 213 *) (* XXX current, better parsing *)
-  | Subnet_allocation of int                (* code 220 *)
-  | Virtual_subnet_selection of string      (* code 221 *)
   | Private_classless_static_route of string(* code 249 *) (* XXX current, use better type *)
   | Web_proxy_auto_disc of string           (* code 252 *)
   | End                                     (* code 255 *)
@@ -459,16 +305,10 @@ val sexp_of_dhcp_option : dhcp_option -> Sexplib.Sexp.t
 
 val dhcp_option_to_string : dhcp_option -> string
 
-val collect_associated_ips : dhcp_option list -> Ipaddr.V4.t list
-val collect_bcmcs_controller_ipv4_addrs : dhcp_option list -> Ipaddr.V4.t list
-val collect_cookie_servers : dhcp_option list -> Ipaddr.V4.t list
 val collect_dns_servers : dhcp_option list -> Ipaddr.V4.t list
-val collect_finger_servers : dhcp_option list -> Ipaddr.V4.t list
-val collect_impress_servers : dhcp_option list -> Ipaddr.V4.t list
 val collect_irc_servers : dhcp_option list -> Ipaddr.V4.t list
 val collect_log_servers : dhcp_option list -> Ipaddr.V4.t list
 val collect_lpr_servers : dhcp_option list -> Ipaddr.V4.t list
-val collect_name_servers : dhcp_option list -> Ipaddr.V4.t list
 val collect_netbios_datagram_distrib_servers : dhcp_option list -> Ipaddr.V4.t list
 val collect_netbios_name_servers : dhcp_option list -> Ipaddr.V4.t list
 val collect_nis_plus_servers : dhcp_option list -> Ipaddr.V4.t list
@@ -477,142 +317,71 @@ val collect_ntp_servers : dhcp_option list -> Ipaddr.V4.t list
 val find_parameter_requests : dhcp_option list -> option_code list option
 val collect_policy_filters : dhcp_option list -> Ipaddr.V4.Prefix.t list
 val collect_routers : dhcp_option list -> Ipaddr.V4.t list
-val collect_rsc_location_servers : dhcp_option list -> Ipaddr.V4.t list
 val collect_static_routes : dhcp_option list -> (Ipaddr.V4.t * Ipaddr.V4.t) list
-val collect_streettalk_da : dhcp_option list -> Ipaddr.V4.t list
-val collect_streettalk_servers : dhcp_option list -> Ipaddr.V4.t list
-val collect_time_servers : dhcp_option list -> Ipaddr.V4.t list
-val collect_www_servers : dhcp_option list -> Ipaddr.V4.t list
 val collect_xwindow_display_managers : dhcp_option list -> Ipaddr.V4.t list
 val collect_xwindow_font_servers : dhcp_option list -> Ipaddr.V4.t list
-val find_absolute_time : dhcp_option list -> int32 option
 val find_all_subnets_local : dhcp_option list -> bool option
 val find_arp_cache_timo : dhcp_option list -> int32 option
-val find_authentication : dhcp_option list -> string option
-val find_auto_config : dhcp_option list -> int option
-val find_bcmcs_controller_domain_name : dhcp_option list -> string option
 val find_bootfile_name : dhcp_option list -> string option
 val find_bootfile_size : dhcp_option list -> int option
 val find_broadcast_addr : dhcp_option list -> Ipaddr.V4.t option
-val find_capwap_ac_v4 : dhcp_option list -> string option
-val find_ccc : dhcp_option list -> string option
 val find_classless_static_route : dhcp_option list -> string option
 val find_client_fqdn : dhcp_option list -> string option
 val find_client_id : dhcp_option list -> client_id option
-val find_client_last_transaction_time : dhcp_option list -> int32 option
 val find_client_ndi : dhcp_option list -> string option
 val find_client_system : dhcp_option list -> string option
-val find_configuration_file : dhcp_option list -> string option
-val find_data_source : dhcp_option list -> int option
 val find_default_ip_ttl : dhcp_option list -> int option
-val find_dhcp_captive_portal : dhcp_option list -> string option
-val find_dhcp_state : dhcp_option list -> int option
-val find_directory_agent : dhcp_option list -> string option
 val find_domain_name : dhcp_option list -> string option
 val find_domain_search : dhcp_option list -> string option
-val find_etherboot_175 : dhcp_option list -> string option
-val find_etherboot_177 : dhcp_option list -> string option
 val find_ethernet_encapsulation : dhcp_option list -> bool option
 val find_extension_path : dhcp_option list -> string option
-val find_forcenew_nonce_capable : dhcp_option list -> string option
-val find_geoconf : dhcp_option list -> string option
-val find_geoconf_civic : dhcp_option list -> string option
-val find_geolock : dhcp_option list -> string option
 val find_hostname : dhcp_option list -> string option
 val find_interface_mtu : dhcp_option list -> int option
 val find_ip_lease_time : dhcp_option list -> int32 option
-val find_ip_telefone : dhcp_option list -> string option
 val find_ipforwarding : dhcp_option list -> bool option
-val find_ipv4_address_andsf : dhcp_option list -> string option
-val find_ipv4_address_mos : dhcp_option list -> string option
-val find_ipv4_fqdn_mos : dhcp_option list -> string option
-val find_isns : dhcp_option list -> string option
-val find_ldap : dhcp_option list -> string option
-val find_mask_supplier : dhcp_option list -> bool option
 val find_max_datagram : dhcp_option list -> int option
 val find_max_message : dhcp_option list -> int option
-val find_merit_dumpfile : dhcp_option list -> string option
 val find_message : dhcp_option list -> string option
 val find_message_type : dhcp_option list -> msgtype option
 val find_misc_150 : dhcp_option list -> string option
 val collect_mobile_ip_home_agent : dhcp_option list -> Ipaddr.V4.t list
-val find_name_service_search : dhcp_option list -> string option
-val find_nds_context : dhcp_option list -> string option
-val find_nds_servers : dhcp_option list -> string option
-val find_nds_tree_name : dhcp_option list -> string option
 val find_netbios_node : dhcp_option list -> int option
 val find_netbios_scope : dhcp_option list -> string option
-val find_netinfo_address : dhcp_option list -> string option
-val find_netinfo_tag : dhcp_option list -> string option
-val find_netware_ip_domain : dhcp_option list -> string option
-val find_netware_ip_option : dhcp_option list -> string option
 val find_nis_domain : dhcp_option list -> string option
 val find_nis_plus_domain : dhcp_option list -> string option
 val find_nlsr : dhcp_option list -> bool option
 val collect_nntp_servers : dhcp_option list -> Ipaddr.V4.t list
-val find_option_6rd : dhcp_option list -> string option
 val find_option_overload : dhcp_option list -> int option
-val find_pana_agent : dhcp_option list -> string option
-val find_path_prefix : dhcp_option list -> string option
 val find_pcode : dhcp_option list -> string option
-val find_perform_mask_discovery : dhcp_option list -> bool option
 val find_perform_router_disc : dhcp_option list -> bool option
-val find_pmtu_ageing_timo : dhcp_option list -> int32 option
-val find_pmtu_plateau_table : dhcp_option list -> int list option
 val collect_pop3_servers : dhcp_option list -> Ipaddr.V4.t list
-val find_private_classless_static_route : dhcp_option list -> string option
-val find_pxe_128 : dhcp_option list -> string option
-val find_pxe_129 : dhcp_option list -> string option
-val find_pxe_130 : dhcp_option list -> string option
-val find_pxe_131 : dhcp_option list -> string option
-val find_pxe_132 : dhcp_option list -> string option
-val find_pxe_133 : dhcp_option list -> string option
-val find_pxe_134 : dhcp_option list -> string option
-val find_pxe_135 : dhcp_option list -> string option
-val find_pxe_linux : dhcp_option list -> int32 option
-val find_query_end_time : dhcp_option list -> int32 option
-val find_query_start_time : dhcp_option list -> int32 option
 val find_rapid_commit : dhcp_option list -> dhcp_option option
-val find_rdnss_selection : dhcp_option list -> string option
 val find_rebinding_t2 : dhcp_option list -> int32 option
-val find_reboot_time : dhcp_option list -> int32 option
 val find_relay_agent_information : dhcp_option list -> string option
 val find_renewal_t1 : dhcp_option list -> int32 option
 val find_request_ip : dhcp_option list -> Ipaddr.V4.t option
 val find_root_path : dhcp_option list -> string option
 val find_router_sol_addr : dhcp_option list -> Ipaddr.V4.t option
 val find_server_identifier : dhcp_option list -> Ipaddr.V4.t option
-val find_service_scope : dhcp_option list -> string option
 val find_sip_servers : dhcp_option list -> string option
-val find_sip_ua_domains : dhcp_option list -> string option
 val collect_smtp_servers : dhcp_option list -> Ipaddr.V4.t list
-val find_start_time_of_state : dhcp_option list -> int32 option
-val find_status_code : dhcp_option list -> string option
-val find_subnet_allocation : dhcp_option list -> int option
 val find_subnet_mask : dhcp_option list -> Ipaddr.V4.t option
 val find_subnet_selection : dhcp_option list -> Ipaddr.V4.t option
 val find_swap_server : dhcp_option list -> Ipaddr.V4.t option
 val find_tcode : dhcp_option list -> string option
+val find_ipv6only : dhcp_option list -> int32 option
 val find_tcp_default_ttl : dhcp_option list -> int option
-val find_tcp_keepalive_garbage : dhcp_option list -> int option
 val find_tcp_keepalive_interval : dhcp_option list -> int32 option
 val find_tftp_server_name : dhcp_option list -> string option
 val find_time_offset : dhcp_option list -> int32 option
 val find_trailer_encapsulation : dhcp_option list -> bool option
-val find_url : dhcp_option list -> string option
-val find_user_auth : dhcp_option list -> string option
 val find_user_class : dhcp_option list -> string option
 val find_uuid_guid : dhcp_option list -> string option
-val find_v4_access_domain : dhcp_option list -> string option
-val find_v4_lost : dhcp_option list -> string option
-val find_v4_pcp_server : dhcp_option list -> string option
-val find_v4_portparams : dhcp_option list -> string option
 val find_vendor_class_id : dhcp_option list -> string option
 val find_vendor_specific : dhcp_option list -> string option
-val find_vi_vendor_class : dhcp_option list -> string option
 val find_vi_vendor_info : dhcp_option list -> string option
-val find_virtual_subnet_selection : dhcp_option list -> string option
 val find_web_proxy_auto_disc : dhcp_option list -> string option
+val find_private_classless_static_route : dhcp_option list -> string option
 val find_unassigned : int -> dhcp_option list -> (int * string) option
 val collect_unassigned : int -> dhcp_option list -> (int * string) list
 

--- a/lib/dhcp_wire.mli
+++ b/lib/dhcp_wire.mli
@@ -149,7 +149,7 @@ type option_code =
   | PRIVATE_CLASSLESS_STATIC_ROUTE
   | WEB_PROXY_AUTO_DISC
   | END
-  | UNKNOWN of int
+  | OTHER of int
 (** The type of a dhcp parameter request, these are all the values according to
     {{:https://www.iana.org/assignments/bootp-dhcp-parameters/bootp-dhcp-parameters.xhtml}iana}
 *)
@@ -282,7 +282,7 @@ type dhcp_option =
   | Private_classless_static_route of string(* code 249 *) (* XXX current, use better type *)
   | Web_proxy_auto_disc of string           (* code 252 *)
   | End                                     (* code 255 *)
-  | Unassigned of int * string              (* int * string *)
+  | Other of int * string              (* int * string *)
   [@@deriving sexp]
 (** Not all options are currently implemented. *)
 
@@ -382,8 +382,8 @@ val find_vendor_specific : dhcp_option list -> string option
 val find_vi_vendor_info : dhcp_option list -> string option
 val find_web_proxy_auto_disc : dhcp_option list -> string option
 val find_private_classless_static_route : dhcp_option list -> string option
-val find_unassigned : int -> dhcp_option list -> (int * string) option
-val collect_unassigned : int -> dhcp_option list -> (int * string) list
+val find_other : int -> dhcp_option list -> (int * string) option
+val collect_other : int -> dhcp_option list -> (int * string) list
 
 (** {2 DHCP Packet - fixed-length fields, plus a variable-length list of options} *)
 

--- a/lib/dhcp_wire.mli
+++ b/lib/dhcp_wire.mli
@@ -35,9 +35,6 @@ val int_to_op_exn : int -> op
 (** @raise Invalid_argument if [v < 0 || v > 255]  *)
 val op_to_int : op -> int
 
-val string_to_op : string -> op option
-val op_to_string : op -> string
-
 val sexp_of_op : op -> Sexplib.Sexp.t
 val op_of_sexp : Sexplib.Sexp.t -> op
 
@@ -66,9 +63,6 @@ val msgtype_to_int : msgtype -> int
 val int_to_msgtype : int -> msgtype option
 val int_to_msgtype_exn : int -> msgtype
 (** @raise Invalid_argument if not a valid {! msgtype} value *)
-
-val string_to_msgtype : string -> msgtype option
-val msgtype_to_string : msgtype -> string
 
 val sexp_of_msgtype : msgtype -> Sexplib.Sexp.t
 val msgtype_of_sexp : Sexplib.Sexp.t -> msgtype
@@ -160,7 +154,6 @@ type option_code =
   | CLIENT_FQDN
   | RELAY_AGENT_INFORMATION
   | ISNS
-  | UNASSIGNED_84
   | NDS_SERVERS
   | NDS_TREE_NAME
   | NDS_CONTEXT
@@ -172,26 +165,14 @@ type option_code =
   | CLIENT_SYSTEM
   | CLIENT_NDI
   | LDAP
-  | UNASSIGNED_96
   | UUID_GUID
   | USER_AUTH
   | GEOCONF_CIVIC
   | PCODE
   | TCODE
-  | UNASSIGNED_102
-  | UNASSIGNED_103
-  | UNASSIGNED_104
-  | UNASSIGNED_105
-  | UNASSIGNED_106
-  | UNASSIGNED_107
-  | UNASSIGNED_108
-  | UNASSIGNED_109
-  | UNASSIGNED_110
-  | UNASSIGNED_111
   | NETINFO_ADDRESS
   | NETINFO_TAG
   | URL
-  | UNASSIGNED_115
   | AUTO_CONFIG
   | NAME_SERVICE_SEARCH
   | SUBNET_SELECTION
@@ -202,8 +183,6 @@ type option_code =
   | GEOCONF
   | VI_VENDOR_CLASS
   | VI_VENDOR_INFO
-  | UNASSIGNED_126
-  | UNASSIGNED_127
   | PXE_128
   | PXE_129
   | PXE_130
@@ -219,13 +198,9 @@ type option_code =
   | IPV4_FQDN_MOS
   | SIP_UA_DOMAINS
   | IPV4_ADDRESS_ANDSF
-  | UNASSIGNED_143
   | GEOLOCK
   | FORCENEW_NONCE_CAPABLE
   | RDNSS_SELECTION
-  | UNASSIGNED_147
-  | UNASSIGNED_148
-  | UNASSIGNED_149
   | MISC_150
   | STATUS_CODE
   | ABSOLUTE_TIME
@@ -237,104 +212,24 @@ type option_code =
   | V4_PCP_SERVER
   | V4_PORTPARAMS
   | DHCP_CAPTIVE_PORTAL
-  | UNASSIGNED_161
-  | UNASSIGNED_162
-  | UNASSIGNED_163
-  | UNASSIGNED_164
-  | UNASSIGNED_165
-  | UNASSIGNED_166
-  | UNASSIGNED_167
-  | UNASSIGNED_168
-  | UNASSIGNED_169
-  | UNASSIGNED_170
-  | UNASSIGNED_171
-  | UNASSIGNED_172
-  | UNASSIGNED_173
-  | UNASSIGNED_174
   | ETHERBOOT_175
   | IP_TELEFONE
   | ETHERBOOT_177
-  | UNASSIGNED_178
-  | UNASSIGNED_179
-  | UNASSIGNED_180
-  | UNASSIGNED_181
-  | UNASSIGNED_182
-  | UNASSIGNED_183
-  | UNASSIGNED_184
-  | UNASSIGNED_185
-  | UNASSIGNED_186
-  | UNASSIGNED_187
-  | UNASSIGNED_188
-  | UNASSIGNED_189
-  | UNASSIGNED_190
-  | UNASSIGNED_191
-  | UNASSIGNED_192
-  | UNASSIGNED_193
-  | UNASSIGNED_194
-  | UNASSIGNED_195
-  | UNASSIGNED_196
-  | UNASSIGNED_197
-  | UNASSIGNED_198
-  | UNASSIGNED_199
-  | UNASSIGNED_200
-  | UNASSIGNED_201
-  | UNASSIGNED_202
-  | UNASSIGNED_203
-  | UNASSIGNED_204
-  | UNASSIGNED_205
-  | UNASSIGNED_206
-  | UNASSIGNED_207
   | PXE_LINUX
   | CONFIGURATION_FILE
   | PATH_PREFIX
   | REBOOT_TIME
   | OPTION_6RD
   | V4_ACCESS_DOMAIN
-  | UNASSIGNED_214
-  | UNASSIGNED_215
-  | UNASSIGNED_216
-  | UNASSIGNED_217
-  | UNASSIGNED_218
-  | UNASSIGNED_219
   | SUBNET_ALLOCATION
   | VIRTUAL_SUBNET_SELECTION
-  | UNASSIGNED_222
-  | UNASSIGNED_223
-  | RESERVED_224
-  | RESERVED_225
-  | RESERVED_226
-  | RESERVED_227
-  | RESERVED_228
-  | RESERVED_229
-  | RESERVED_230
-  | RESERVED_231
-  | RESERVED_232
-  | RESERVED_233
-  | RESERVED_234
-  | RESERVED_235
-  | RESERVED_236
-  | RESERVED_237
-  | RESERVED_238
-  | RESERVED_239
-  | RESERVED_240
-  | RESERVED_241
-  | RESERVED_242
-  | RESERVED_243
-  | RESERVED_244
-  | RESERVED_245
-  | RESERVED_246
-  | RESERVED_247
-  | RESERVED_248
   | PRIVATE_CLASSLESS_STATIC_ROUTE
-  | RESERVED_250
-  | RESERVED_251
   | WEB_PROXY_AUTO_DISC
-  | RESERVED_253
-  | RESERVED_254
   | END
+  | UNKNOWN of int
 (** The type of a dhcp parameter request, these are all the values according to
     {{:https://www.iana.org/assignments/bootp-dhcp-parameters/bootp-dhcp-parameters.xhtml}iana}
-*) 
+*)
 
 (** Conversions of DHCP {! option_code}s. *)
 
@@ -344,9 +239,6 @@ val option_code_to_int : option_code -> int
 
 val sexp_of_option_code : option_code -> Sexplib.Sexp.t
 val option_code_of_sexp : Sexplib.Sexp.t -> option_code
-
-val string_to_option_code : string -> option_code option
-val option_code_to_string : option_code -> string
 
 (** {2 DHCP hardware type} *)
 
@@ -544,7 +436,7 @@ type dhcp_option =
   | Private_classless_static_route of string(* code 249 *) (* XXX current, use better type *)
   | Web_proxy_auto_disc of string           (* code 252 *)
   | End                                     (* code 255 *)
-  | Unassigned of option_code * string      (* code * string *)
+  | Unassigned of int * string              (* int * string *)
   [@@deriving sexp]
 (** Not all options are currently implemented. *)
 
@@ -721,8 +613,8 @@ val find_vi_vendor_class : dhcp_option list -> string option
 val find_vi_vendor_info : dhcp_option list -> string option
 val find_virtual_subnet_selection : dhcp_option list -> string option
 val find_web_proxy_auto_disc : dhcp_option list -> string option
-val find_unassigned : option_code -> dhcp_option list -> (option_code * string) option
-val collect_unassigned : option_code -> dhcp_option list -> (option_code * string) list
+val find_unassigned : int -> dhcp_option list -> (int * string) option
+val collect_unassigned : int -> dhcp_option list -> (int * string) list
 
 (** {2 DHCP Packet - fixed-length fields, plus a variable-length list of options} *)
 

--- a/lib/dune
+++ b/lib/dune
@@ -1,6 +1,4 @@
 (library
  (name dhcp_wire)
  (public_name charrua)
- (preprocess (pps ppx_sexp_conv))
- (libraries cstruct ethernet sexplib tcpip.ipv4 tcpip.udp ipaddr ipaddr-sexp
-            macaddr macaddr-sexp))
+ (libraries cstruct ethernet tcpip.ipv4 tcpip.udp ipaddr macaddr fmt ohex))

--- a/lib/dune
+++ b/lib/dune
@@ -1,6 +1,6 @@
 (library
  (name dhcp_wire)
  (public_name charrua)
- (preprocess (pps ppx_sexp_conv ppx_cstruct))
+ (preprocess (pps ppx_sexp_conv))
  (libraries cstruct ethernet sexplib tcpip.ipv4 tcpip.udp ipaddr ipaddr-sexp
             macaddr macaddr-sexp))

--- a/server/dhcp_server.ml
+++ b/server/dhcp_server.ml
@@ -482,7 +482,7 @@ module Input = struct
         preqs
     in
     let unassigned_options =
-      List.filter (function Unassigned (_ ,_) -> true | _ -> false)
+      List.filter (function Other (_ ,_) -> true | _ -> false)
         options
     in
     (* matches multiple options *)
@@ -590,9 +590,9 @@ module Input = struct
         s find_web_proxy_auto_disc (fun x -> Web_proxy_auto_disc x)
       | PRIVATE_CLASSLESS_STATIC_ROUTE ->
         s find_private_classless_static_route (fun x -> Private_classless_static_route x)
-      | UNKNOWN code ->
+      | OTHER code ->
         find_option
-          (function Unassigned (c, _s) as u when c = code -> Some u | _ -> None)
+          (function Other (c, _s) as u when c = code -> Some u | _ -> None)
           unassigned_options
       | PAD | END -> None       (* Senseless *)
     in

--- a/server/dhcp_server.ml
+++ b/server/dhcp_server.ml
@@ -501,18 +501,11 @@ module Input = struct
       | SUBNET_MASK -> s find_subnet_mask (fun x -> Subnet_mask x)
       | TIME_OFFSET -> s find_time_offset (fun x -> Time_offset x)
       | ROUTERS -> m collect_routers (fun x -> Routers x)
-      | TIME_SERVERS -> m collect_time_servers (fun x -> Time_servers x)
-      | NAME_SERVERS -> m collect_name_servers (fun x -> Name_servers x)
       | DNS_SERVERS -> m collect_dns_servers (fun x -> Dns_servers x)
       | LOG_SERVERS -> m collect_log_servers (fun x -> Log_servers x)
-      | COOKIE_SERVERS -> m collect_cookie_servers (fun x -> Cookie_servers x)
       | LPR_SERVERS -> m collect_lpr_servers (fun x -> Lpr_servers x)
-      | IMPRESS_SERVERS -> m collect_impress_servers (fun x -> Impress_servers x)
-      | RSCLOCATION_SERVERS ->
-        m collect_rsc_location_servers (fun x -> Rsclocation_servers x)
       | HOSTNAME -> s find_hostname (fun x -> Hostname x)
       | BOOTFILE_SIZE -> s find_bootfile_size (fun x -> Bootfile_size x)
-      | MERIT_DUMPFILE -> s find_merit_dumpfile (fun x -> Merit_dumpfile x)
       | DOMAIN_NAME -> s find_domain_name (fun x -> Domain_name x)
       | SWAP_SERVER -> s find_swap_server (fun x -> Swap_server x)
       | ROOT_PATH -> s find_root_path (fun x -> Root_path x)
@@ -522,15 +515,9 @@ module Input = struct
       | POLICY_FILTERS -> m collect_policy_filters (fun x -> Policy_filters x)
       | MAX_DATAGRAM -> s find_max_datagram (fun x -> Max_datagram x)
       | DEFAULT_IP_TTL -> s find_default_ip_ttl (fun x -> Default_ip_ttl x)
-      | PMTU_AGEING_TIMO -> s find_pmtu_ageing_timo (fun x -> Pmtu_ageing_timo x)
-      | PMTU_PLATEAU_TABLE ->
-        s find_pmtu_plateau_table (fun x -> Pmtu_plateau_table x)
       | INTERFACE_MTU -> s find_interface_mtu (fun x -> Interface_mtu x)
       | ALL_SUBNETS_LOCAL -> s find_all_subnets_local (fun x -> All_subnets_local x)
       | BROADCAST_ADDR -> s find_broadcast_addr (fun x -> Broadcast_addr x)
-      | PERFORM_MASK_DISCOVERY ->
-        s find_perform_mask_discovery (fun x -> Perform_router_disc x)
-      | MASK_SUPPLIER -> s find_mask_supplier (fun x -> Mask_supplier x)
       | PERFORM_ROUTER_DISC ->
         s find_perform_router_disc (fun x -> Perform_router_disc x)
       | ROUTER_SOL_ADDR -> s find_router_sol_addr (fun x -> Router_sol_addr x)
@@ -543,8 +530,6 @@ module Input = struct
       | TCP_DEFAULT_TTL -> s find_tcp_default_ttl (fun x -> Tcp_default_ttl x)
       | TCP_KEEPALIVE_INTERVAL ->
         s find_tcp_keepalive_interval (fun x -> Tcp_keepalive_interval x)
-      | TCP_KEEPALIVE_GARBAGE ->
-        s find_tcp_keepalive_garbage (fun x -> Tcp_keepalive_garbage x)
       | NIS_DOMAIN -> s find_nis_domain (fun x -> Nis_domain x)
       | NIS_SERVERS -> m collect_nis_servers (fun x -> Nis_servers x)
       | NTP_SERVERS -> m collect_ntp_servers (fun x -> Ntp_servers x)
@@ -572,10 +557,6 @@ module Input = struct
       | REBINDING_T2 -> None (* Previously included *)
       | VENDOR_CLASS_ID -> s find_vendor_class_id (fun x -> Vendor_class_id x)
       | CLIENT_ID -> None (* Senseless *)
-      | NETWARE_IP_DOMAIN ->
-        s find_netware_ip_domain (fun x -> Netware_ip_domain x)
-      | NETWARE_IP_OPTION ->
-        s find_netware_ip_option (fun x -> Netware_ip_option x)
       | NIS_PLUS_DOMAIN -> s find_nis_plus_domain (fun x -> Nis_plus_domain x)
       | NIS_PLUS_SERVERS ->
         m collect_nis_plus_servers (fun x -> Nis_plus_servers x)
@@ -586,105 +567,25 @@ module Input = struct
       | SMTP_SERVERS -> m collect_smtp_servers (fun x -> Smtp_servers x)
       | POP3_SERVERS -> m collect_pop3_servers (fun x -> Pop3_servers x)
       | NNTP_SERVERS -> m collect_nntp_servers (fun x -> Nntp_servers x)
-      | WWW_SERVERS -> m collect_www_servers (fun x -> Www_servers x)
-      | FINGER_SERVERS -> m collect_finger_servers (fun x -> Finger_servers x)
       | IRC_SERVERS -> m collect_irc_servers (fun x -> Irc_servers x)
-      | STREETTALK_SERVERS ->
-        m collect_streettalk_servers (fun x -> Streettalk_servers x)
-      | STREETTALK_DA ->
-        m collect_streettalk_da (fun x -> Streettalk_da x)
       | USER_CLASS -> s find_user_class (fun x -> User_class x)
-      | DIRECTORY_AGENT -> s find_directory_agent (fun x -> Directory_agent x)
-      | SERVICE_SCOPE -> s find_service_scope (fun x -> Service_scope x)
       | RAPID_COMMIT -> s find_rapid_commit (fun _ -> Rapid_commit)
       | CLIENT_FQDN -> s find_client_fqdn (fun x -> Client_fqdn x)
       | RELAY_AGENT_INFORMATION ->
         s find_relay_agent_information (fun x -> Relay_agent_information x)
-      | ISNS -> s find_isns (fun x -> Isns x)
-      | NDS_SERVERS -> s find_nds_servers (fun x -> Nds_servers x)
-      | NDS_TREE_NAME -> s find_nds_tree_name (fun x -> Nds_tree_name x)
-      | NDS_CONTEXT -> s find_nds_context (fun x -> Nds_context x)
-      | BCMCS_CONTROLLER_DOMAIN_NAME_LIST ->
-        s find_bcmcs_controller_domain_name
-          (fun x -> Bcmcs_controller_domain_name_list x)
-      | BCMCS_CONTROLLER_IPV4_ADDR ->
-        m collect_bcmcs_controller_ipv4_addrs
-          (fun x -> Bcmcs_controller_ipv4_addrs x)
-      | AUTHENTICATION -> s find_authentication (fun x -> Authentication x)
-      | CLIENT_LAST_TRANSACTION_TIME ->
-        s find_client_last_transaction_time
-          (fun x -> Client_last_transaction_time x)
-      | ASSOCIATED_IPS -> m collect_associated_ips (fun x -> Associated_ips x)
       | CLIENT_SYSTEM -> s find_client_system (fun x -> Client_system x)
       | CLIENT_NDI -> s find_client_ndi (fun x -> Client_ndi x)
-      | LDAP -> s find_ldap (fun x -> Ldap x)
       | UUID_GUID -> s find_uuid_guid (fun x -> Uuid_guid x)
-      | USER_AUTH -> s find_user_auth (fun x -> User_auth x)
-      | GEOCONF_CIVIC -> s find_geoconf_civic (fun x -> Geoconf_civic x)
       | PCODE -> s find_pcode (fun x -> Pcode x)
       | TCODE -> s find_tcode (fun x -> Tcode x)
-      | NETINFO_ADDRESS -> s find_netinfo_address (fun x -> Netinfo_address x)
-      | NETINFO_TAG -> s find_netinfo_tag (fun x -> Netinfo_tag x)
-      | URL -> s find_url (fun x -> Url x)
-      | AUTO_CONFIG -> s find_auto_config (fun x -> Auto_config x)
-      | NAME_SERVICE_SEARCH ->
-        s find_name_service_search (fun x -> Name_service_search x)
+      | IPV6ONLY -> s find_ipv6only (fun x -> IPv6_only x)
       | SUBNET_SELECTION -> s find_subnet_selection (fun x -> Subnet_selection x)
       | DOMAIN_SEARCH -> s find_domain_search (fun x -> Domain_search x)
       | SIP_SERVERS -> s find_sip_servers (fun x -> Sip_servers x)
       | CLASSLESS_STATIC_ROUTE ->
         s find_classless_static_route (fun x -> Classless_static_route x)
-      | CCC -> s find_ccc (fun x -> Ccc x)
-      | GEOCONF -> s find_geoconf (fun x -> Geoconf x)
-      | VI_VENDOR_CLASS -> s find_vi_vendor_class (fun x -> Vi_vendor_class x)
       | VI_VENDOR_INFO -> s find_vi_vendor_info (fun x -> Vi_vendor_info x)
-      | PXE_128 -> s find_pxe_128 (fun x -> Pxe_128 x)
-      | PXE_129 -> s find_pxe_129 (fun x -> Pxe_129 x)
-      | PXE_130 -> s find_pxe_130 (fun x -> Pxe_130 x)
-      | PXE_131 -> s find_pxe_131 (fun x -> Pxe_131 x)
-      | PXE_132 -> s find_pxe_132 (fun x -> Pxe_132 x)
-      | PXE_133 -> s find_pxe_133 (fun x -> Pxe_133 x)
-      | PXE_134 -> s find_pxe_134 (fun x -> Pxe_134 x)
-      | PXE_135 -> s find_pxe_135 (fun x -> Pxe_135 x)
-      | PANA_AGENT -> s find_pana_agent (fun x -> Pana_agent x)
-      | V4_LOST -> s find_v4_lost (fun x -> V4_lost x)
-      | CAPWAP_AC_V4 -> s find_capwap_ac_v4 (fun x -> Capwap_ac_v4 x)
-      | IPV4_ADDRESS_MOS -> s find_ipv4_address_mos (fun x -> Ipv4_address_mos x)
-      | IPV4_FQDN_MOS -> s find_ipv4_fqdn_mos (fun x -> Ipv4_fqdn_mos x)
-      | SIP_UA_DOMAINS -> s find_sip_ua_domains (fun x -> Sip_ua_domains x)
-      | IPV4_ADDRESS_ANDSF ->
-        s find_ipv4_address_andsf (fun x -> Ipv4_address_andsf x)
-      | GEOLOCK -> s find_geolock (fun x -> Geolock x)
-      | FORCENEW_NONCE_CAPABLE ->
-        s find_forcenew_nonce_capable (fun x -> Forcenew_nonce_capable x)
-      | RDNSS_SELECTION -> s find_rdnss_selection (fun x -> Rdnss_selection x)
       | MISC_150 -> s find_misc_150 (fun x -> Misc_150 x)
-      | STATUS_CODE -> s find_status_code (fun x -> Status_code x)
-      | ABSOLUTE_TIME -> s find_absolute_time (fun x -> Absolute_time x)
-      | START_TIME_OF_STATE ->
-        s find_start_time_of_state (fun x -> Start_time_of_state x)
-      | QUERY_START_TIME -> s find_query_end_time (fun x -> Query_start_time x)
-      | QUERY_END_TIME -> s find_query_end_time (fun x -> Query_end_time x)
-      | DHCP_STATE -> s find_dhcp_state (fun x -> Dhcp_state x)
-      | DATA_SOURCE -> s find_data_source (fun x -> Data_source x)
-      | V4_PCP_SERVER -> s find_v4_pcp_server (fun x -> V4_pcp_server x)
-      | V4_PORTPARAMS -> s find_v4_portparams (fun x -> V4_portparams x)
-      | DHCP_CAPTIVE_PORTAL ->
-        s find_dhcp_captive_portal (fun x -> Dhcp_captive_portal x)
-      | ETHERBOOT_175 -> s find_etherboot_175 (fun x -> Etherboot_175 x)
-      | IP_TELEFONE -> s find_ip_telefone (fun x -> Ip_telefone x)
-      | ETHERBOOT_177 -> s find_etherboot_177 (fun x -> Etherboot_177 x)
-      | PXE_LINUX -> s find_pxe_linux (fun x -> Pxe_linux x)
-      | CONFIGURATION_FILE ->
-        s find_configuration_file (fun x -> Configuration_file x)
-      | PATH_PREFIX -> s find_path_prefix (fun x -> Path_prefix x)
-      | REBOOT_TIME -> s find_reboot_time (fun x -> Reboot_time x)
-      | OPTION_6RD -> s find_option_6rd (fun x -> Option_6rd x)
-      | V4_ACCESS_DOMAIN -> s find_v4_access_domain (fun x -> V4_access_domain x)
-      | SUBNET_ALLOCATION ->
-        s find_subnet_allocation (fun x -> Subnet_allocation x)
-      | VIRTUAL_SUBNET_SELECTION ->
-        s find_virtual_subnet_selection (fun x -> Virtual_subnet_selection x)
       | WEB_PROXY_AUTO_DISC ->
         s find_web_proxy_auto_disc (fun x -> Web_proxy_auto_disc x)
       | PRIVATE_CLASSLESS_STATIC_ROUTE ->

--- a/server/dhcp_server.ml
+++ b/server/dhcp_server.ml
@@ -442,7 +442,7 @@ module Input = struct
             (reqpkt.srcmac, yiaddr)
           else
             (Macaddr.broadcast, Ipaddr.V4.broadcast)
-        | _ -> invalid_arg ("Can't send message type " ^ (msgtype_to_string m))
+        | _ -> invalid_arg ("Can't send message type " ^ string_of_int (msgtype_to_int m))
     in
     let srcip = config.ip_addr in
     { srcmac; dstmac; srcip; dstip; srcport; dstport;
@@ -689,32 +689,7 @@ module Input = struct
         s find_web_proxy_auto_disc (fun x -> Web_proxy_auto_disc x)
       | PRIVATE_CLASSLESS_STATIC_ROUTE ->
         s find_private_classless_static_route (fun x -> Private_classless_static_route x)
-      | UNASSIGNED_84  | UNASSIGNED_96  | UNASSIGNED_102 | UNASSIGNED_103
-      | UNASSIGNED_104 | UNASSIGNED_105 | UNASSIGNED_106 | UNASSIGNED_107
-      | UNASSIGNED_108 | UNASSIGNED_109 | UNASSIGNED_110 | UNASSIGNED_111
-      | UNASSIGNED_115 | UNASSIGNED_126 | UNASSIGNED_127 | UNASSIGNED_143
-      | UNASSIGNED_147 | UNASSIGNED_148 | UNASSIGNED_149 | UNASSIGNED_161
-      | UNASSIGNED_162 | UNASSIGNED_163 | UNASSIGNED_164 | UNASSIGNED_165
-      | UNASSIGNED_166 | UNASSIGNED_167 | UNASSIGNED_168 | UNASSIGNED_169
-      | UNASSIGNED_170 | UNASSIGNED_171 | UNASSIGNED_172 | UNASSIGNED_173
-      | UNASSIGNED_174 | UNASSIGNED_178 | UNASSIGNED_179 | UNASSIGNED_180
-      | UNASSIGNED_181 | UNASSIGNED_182 | UNASSIGNED_183 | UNASSIGNED_184
-      | UNASSIGNED_185 | UNASSIGNED_186 | UNASSIGNED_187 | UNASSIGNED_188
-      | UNASSIGNED_189 | UNASSIGNED_190 | UNASSIGNED_191 | UNASSIGNED_192
-      | UNASSIGNED_193 | UNASSIGNED_194 | UNASSIGNED_195 | UNASSIGNED_196
-      | UNASSIGNED_197 | UNASSIGNED_198 | UNASSIGNED_199 | UNASSIGNED_200
-      | UNASSIGNED_201 | UNASSIGNED_202 | UNASSIGNED_203 | UNASSIGNED_204
-      | UNASSIGNED_205 | UNASSIGNED_206 | UNASSIGNED_207 | UNASSIGNED_214
-      | UNASSIGNED_215 | UNASSIGNED_216 | UNASSIGNED_217 | UNASSIGNED_218
-      | UNASSIGNED_219 | UNASSIGNED_222 | UNASSIGNED_223 | RESERVED_224
-      | RESERVED_225   | RESERVED_226   | RESERVED_227   | RESERVED_228
-      | RESERVED_229   | RESERVED_230   | RESERVED_231   | RESERVED_232
-      | RESERVED_233   | RESERVED_234   | RESERVED_235   | RESERVED_236
-      | RESERVED_237   | RESERVED_238   | RESERVED_239   | RESERVED_240
-      | RESERVED_241   | RESERVED_242   | RESERVED_243   | RESERVED_244
-      | RESERVED_245   | RESERVED_246   | RESERVED_247   | RESERVED_248
-      | RESERVED_250   | RESERVED_251   | RESERVED_253   | RESERVED_254
-      as code ->
+      | UNKNOWN code ->
         find_option
           (function Unassigned (c, _s) as u when c = code -> Some u | _ -> None)
           unassigned_options
@@ -731,7 +706,7 @@ module Input = struct
 
   let input_decline config db pkt now =
     let msgtype = match find_message_type pkt.options with
-      | Some msgtype -> msgtype_to_string msgtype
+      | Some msgtype -> string_of_int (msgtype_to_int msgtype)
       | None -> failwith "Unexpected message type"
     in
     let ourip = config.ip_addr in
@@ -760,7 +735,7 @@ module Input = struct
 
   let input_release config db pkt now =
     let msgtype = match find_message_type pkt.options with
-      | Some msgtype -> msgtype_to_string msgtype
+      | Some msgtype -> string_of_int (msgtype_to_int msgtype)
       | None -> failwith "Unexpected message type"
     in
     let ourip = config.ip_addr in
@@ -973,7 +948,7 @@ module Input = struct
         | Some DHCPRELEASE  -> input_release config db pkt time
         | Some DHCPINFORM   -> input_inform config db pkt
         | None -> bad_packet "Malformed packet: no dhcp msgtype"
-        | Some m -> Warning ("Unhandled msgtype " ^ (msgtype_to_string m))
+        | Some m -> Warning ("Unhandled msgtype " ^ string_of_int (msgtype_to_int m))
       else
         bad_packet "Invalid packet"
     with

--- a/server/dhcp_server.mli
+++ b/server/dhcp_server.mli
@@ -30,7 +30,7 @@ module Config : sig
     options : Dhcp_wire.dhcp_option list;
     fixed_addr : Ipaddr.V4.t option;
     hw_addr : Macaddr.t;
-  } [@@deriving sexp]
+  }
   (** {! host} config section entry. *)
 
   type t = {
@@ -43,7 +43,7 @@ module Config : sig
     network : Ipaddr.V4.Prefix.t;
     range : (Ipaddr.V4.t * Ipaddr.V4.t) option;
     hosts : host list;
-  } [@@deriving sexp]
+  }
   (** Server configuration *)
 
   val parse : string -> (Ipaddr.V4.t * Macaddr.t) -> t
@@ -75,7 +75,7 @@ module Lease : sig
     tm_end     : int32;
     addr       : Ipaddr.V4.t;
     client_id  : Dhcp_wire.client_id;
-  } [@@deriving sexp]
+  }
 
   val make : Dhcp_wire.client_id -> Ipaddr.V4.t -> duration:int32 -> now:int32 -> t
   val make_fixed : Macaddr.t -> Ipaddr.V4.t -> duration:int32 -> now:int32 -> t

--- a/server/dune
+++ b/server/dune
@@ -2,8 +2,7 @@
  (name dhcp_server)
  (public_name charrua-server)
  (private_modules dhcp_lexer dhcp_parser ast util)
- (preprocess (pps ppx_sexp_conv))
- (libraries ipaddr ipaddr-sexp macaddr macaddr-sexp charrua))
+ (libraries ipaddr macaddr charrua))
 
 (menhir (modules dhcp_parser))
 

--- a/test/client/test_client.ml
+++ b/test/client/test_client.ml
@@ -3,7 +3,7 @@ let cstruct = Alcotest.of_pp Cstruct.hexdump_pp
 let msgtype =
   let module M = struct
     type t = Dhcp_wire.msgtype
-    let pp fmt m = Format.fprintf fmt "%u" (Dhcp_wire.msgtype_to_int m)
+    let pp fmt m = Format.fprintf fmt "%s" (Dhcp_wire.msgtype_to_string m)
     let equal p q = (compare p q) = 0
   end in
   (module M : Alcotest.TESTABLE with type t = M.t)

--- a/test/client/test_client.ml
+++ b/test/client/test_client.ml
@@ -3,7 +3,7 @@ let cstruct = Alcotest.of_pp Cstruct.hexdump_pp
 let msgtype =
   let module M = struct
     type t = Dhcp_wire.msgtype
-    let pp fmt m = Format.fprintf fmt "%s" (Dhcp_wire.msgtype_to_string m)
+    let pp fmt m = Format.fprintf fmt "%u" (Dhcp_wire.msgtype_to_int m)
     let equal p q = (compare p q) = 0
   end in
   (module M : Alcotest.TESTABLE with type t = M.t)

--- a/test/dune
+++ b/test/dune
@@ -1,7 +1,6 @@
 (test
  (name test)
  (package charrua-server)
- (preprocess (pps ppx_cstruct))
  (libraries cstruct-unix alcotest charrua charrua-server))
 
 (alias

--- a/test/pcap.ml
+++ b/test/pcap.ml
@@ -80,7 +80,7 @@ let test_packet p len =
   | Error e -> failwith e
   | Ok pkt ->
     if verbose then
-      printf "DHCP: %s\n%!" (Dhcp_wire.pkt_to_string pkt);
+      Format.printf "DHCP: %a\n%!" Dhcp_wire.pp_pkt pkt;
     let buf = Dhcp_wire.buf_of_pkt pkt in
     match (Dhcp_wire.pkt_of_buf buf len) with
     | Error e -> failwith e
@@ -91,7 +91,7 @@ let test_packet p len =
         Cstruct.hexdump p;
         printf "our buf:";
         Cstruct.hexdump buf;
-        printf "generated pkt:\n%s\n" (Dhcp_wire.pkt_to_string pkt2);
+        Format.printf "generated pkt:\n%a\n" Dhcp_wire.pp_pkt pkt2;
         failwith "Serialization bug found !"
   end
 

--- a/test/pcap.ml
+++ b/test/pcap.ml
@@ -21,8 +21,7 @@ let printf = Printf.printf
 
 let verbose = (Array.length Sys.argv) = 2 && Sys.argv.(1) = "-v"
 
-[%%cstruct
-type pcap_header = {
+(*type pcap_header = {
   magic_number:  uint32_t;  (* magic number *)
   version_major: uint16_t;  (* major version number *)
   version_minor: uint16_t;  (* minor version number *)
@@ -30,15 +29,51 @@ type pcap_header = {
   sigfigs:       uint32_t;  (* accuracy of timestamps *)
   snaplen:       uint32_t;  (* max length of captured packets, in octets *)
   network:       uint32_t;  (* data link type *)
-} [@@little_endian]]
+  } *)
 
-[%%cstruct
-type pcap_packet = {
+let get_pcap_header_magic_number cs =
+  Cstruct.LE.get_uint32 cs 0
+
+let get_pcap_header_version_major cs =
+  Cstruct.LE.get_uint16 cs 4
+
+let get_pcap_header_version_minor cs =
+  Cstruct.LE.get_uint16 cs 6
+
+let get_pcap_header_thiszone cs =
+  Cstruct.LE.get_uint32 cs 8
+
+let get_pcap_header_sigfigs cs =
+  Cstruct.LE.get_uint32 cs 12
+
+let get_pcap_header_snaplen cs =
+  Cstruct.LE.get_uint32 cs 16
+
+let get_pcap_header_network cs =
+  Cstruct.LE.get_uint32 cs 20
+
+let sizeof_pcap_header = 24
+
+(* type pcap_packet = {
   ts_sec:  uint32_t;  (* timestamp seconds *)
   ts_usec:  uint32_t; (* timestamp microseconds *)
   incl_len: uint32_t; (* number of octets of packet saved in file *)
   orig_len: uint32_t; (* actual length of packet *)
-} [@@little_endian]]
+   } *)
+
+let get_pcap_packet_ts_sec cs =
+  Cstruct.LE.get_uint32 cs 0
+
+let get_pcap_packet_ts_usec cs =
+  Cstruct.LE.get_uint32 cs 4
+
+let get_pcap_packet_incl_len cs =
+  Cstruct.LE.get_uint32 cs 8
+
+let get_pcap_packet_orig_len cs =
+  Cstruct.LE.get_uint32 cs 12
+
+let sizeof_pcap_packet = 16
 
 let test_packet p len =
   match (Dhcp_wire.pkt_of_buf p len) with

--- a/test/test.ml
+++ b/test/test.ml
@@ -253,7 +253,7 @@ let t_host_options () =
           Routers [ip5_t];
           Log_servers [ip5_t];
           Irc_servers [ip_t];   (* Won't ask must not be present *)
-          Unassigned (157, "\003");        (* Won't ask must not be present *)
+          Other (157, "\003");        (* Won't ask must not be present *)
         ];
       fixed_addr = None;
       hw_addr = mac_t
@@ -275,7 +275,7 @@ let t_host_options () =
   assert ((collect_dns_servers replies) = [ip4_t; ip_t]);
   assert ((collect_log_servers replies) = [ip5_t]);
   assert ((collect_irc_servers replies) = []);
-  assert ((find_unassigned 157 replies) = None);
+  assert ((find_other 157 replies) = None);
   assert ((find_max_message replies) = (Some 1400))
 
 let discover_pkt = {

--- a/test/test.ml
+++ b/test/test.ml
@@ -329,7 +329,7 @@ let t_discover fixed =
       ()
   in
   if verbose then
-    printf "\n%s\n%s\n%!" (yellow "<<DISCOVER>>") (pkt_to_string discover_pkt);
+    Format.printf "\n%s\n%a\n%!" (yellow "<<DISCOVER>>") pp_pkt discover_pkt;
   match Input.input_pkt config (Lease.make_db ()) discover_pkt now with
   | Input.Reply (reply, db) ->
     assert (db = (Lease.make_db ()));
@@ -371,7 +371,7 @@ let t_discover fixed =
     assert ((List.length routers) = 2);
     assert ((List.hd routers) = ip_t);
     if verbose then
-      printf "%s\n%s\n%!" (yellow "<<OFFER>>") (pkt_to_string reply);
+      Format.printf "%s\n%a\n%!" (yellow "<<OFFER>>") pp_pkt reply;
   | _ -> failwith "No reply"
 
 let t_discover_range () = t_discover false
@@ -394,7 +394,7 @@ let t_discover_no_range () =
       ()
   in
   if verbose then
-    printf "\n%s\n%s\n%!" (yellow "<<DISCOVER>>") (pkt_to_string discover_pkt);
+    Format.printf "\n%s\n%a\n%!" (yellow "<<DISCOVER>>") pp_pkt discover_pkt;
   match Input.input_pkt config (Lease.make_db ()) discover_pkt now with
   | Dhcp_server.Input.Warning s -> if s <> "No ips left to offer" then
       failwith "expected string `'No ips left to offer`'"
@@ -425,7 +425,7 @@ let t_discover_no_range_fixed () =
       ()
   in
     if verbose then
-    printf "\n%s\n%s\n%!" (yellow "<<DISCOVER>>") (pkt_to_string discover_pkt);
+      Format.printf "\n%s\n%a\n%!" (yellow "<<DISCOVER>>") pp_pkt discover_pkt;
   match Input.input_pkt config (Lease.make_db ()) discover_pkt now with
   | Input.Reply (reply, db) ->
     assert (db = (Lease.make_db ()));
@@ -464,7 +464,7 @@ let t_discover_no_range_fixed () =
     assert ((List.length routers) = 2);
     assert ((List.hd routers) = ip_t);
     if verbose then
-      printf "%s\n%s\n%!" (yellow "<<OFFER>>") (pkt_to_string reply);
+      Format.printf "%s\n%a\n%!" (yellow "<<OFFER>>") pp_pkt reply;
   | _ -> failwith "No reply"
 
 let t_bad_discover () =
@@ -600,7 +600,7 @@ let t_request_fixed () =
   }
   in
   if verbose then
-    printf "\n%s\n%s\n%!" (yellow "<<REQUEST>>") (pkt_to_string request);
+    Format.printf "\n%s\n%a\n%!" (yellow "<<REQUEST>>") pp_pkt request;
   let db =
     match Input.input_pkt config (Lease.make_db ()) request now with
     | Input.Reply (reply, db) ->
@@ -645,7 +645,7 @@ let t_request_fixed () =
       assert ((List.length routers) = 2);
       assert ((List.hd routers) = ip_t);
       if verbose then
-        printf "%s\n%s\n%!" (yellow "<<ACK>>") (pkt_to_string reply);
+        Format.printf "%s\n%a\n%!" (yellow "<<ACK>>") pp_pkt reply;
       db
     | _ -> failwith "No reply"
   in
@@ -660,7 +660,7 @@ let t_request_fixed () =
       | _ -> failwith "First option is not Message_type"
     in
     if verbose then
-      printf "%s\n%s\n%!" (yellow "<<NAK>>") (pkt_to_string reply);
+      Format.printf "%s\n%a\n%!" (yellow "<<NAK>>") pp_pkt reply;
   | _ -> failwith "No reply"
 
 let t_request () =
@@ -707,7 +707,7 @@ let t_request () =
   }
   in
   if verbose then
-    printf "\n%s\n%s\n%!" (yellow "<<REQUEST>>") (pkt_to_string request);
+    Format.printf "\n%s\n%a\n%!" (yellow "<<REQUEST>>") pp_pkt request;
   let db =
     match Input.input_pkt config (Lease.make_db ()) request now with
     | Input.Reply (reply, db) ->
@@ -763,7 +763,7 @@ let t_request () =
       assert ((List.length routers) = 2);
       assert ((List.hd routers) = ip_t);
       if verbose then
-        printf "%s\n%s\n%!" (yellow "<<ACK>>") (pkt_to_string reply);
+        Format.printf "%s\n%a\n%!" (yellow "<<ACK>>") pp_pkt reply;
       db
     | _ -> failwith "No reply"
   in
@@ -779,7 +779,7 @@ let t_request () =
       | _ -> failwith "First option is not Message_type"
     in
     if verbose then
-      printf "%s\n%s\n%!" (yellow "<<NAK>>") (pkt_to_string reply);
+      Format.printf "%s\n%a\n%!" (yellow "<<NAK>>") pp_pkt reply;
   | _ -> failwith "No reply"
 
 let t_request_no_range () =
@@ -833,7 +833,7 @@ let t_request_no_range () =
   }
   in
   if verbose then
-    printf "\n%s\n%s\n%!" (yellow "<<REQUEST>>") (pkt_to_string request);
+    Format.printf "\n%s\n%a\n%!" (yellow "<<REQUEST>>") pp_pkt request;
   match Input.input_pkt config (Lease.make_db ()) request now with
   | Dhcp_server.Input.Reply (reply, db) ->
     assert (db = (Lease.make_db ()));
@@ -907,7 +907,7 @@ let t_request_no_range_fixed () =
   }
   in
   if verbose then
-    printf "\n%s\n%s\n%!" (yellow "<<REQUEST>>") (pkt_to_string request);
+    Format.printf "\n%s\n%a\n%!" (yellow "<<REQUEST>>") pp_pkt request;
   match Input.input_pkt config (Lease.make_db ()) request now with
   | Input.Reply (reply, db) ->
     (* Check if our new lease is there *)
@@ -952,7 +952,7 @@ let t_request_no_range_fixed () =
     assert ((List.length routers) = 2);
     assert ((List.hd routers) = ip_t);
     if verbose then
-      printf "%s\n%s\n%!" (yellow "<<ACK>>") (pkt_to_string reply)
+      Format.printf "%s\n%a\n%!" (yellow "<<ACK>>") pp_pkt reply
   | _ -> failwith "No reply"
 
 let t_db_serialization () =

--- a/unix/dune
+++ b/unix/dune
@@ -4,4 +4,4 @@
  (public_name charruad)
  (package charrua-unix)
  (libraries charrua charrua-server lwt.unix cstruct-lwt cstruct-unix cmdliner
-   ipaddr tuntap rawlink-lwt mtime.clock.os lwt_log duration))
+   ipaddr tuntap rawlink-lwt mtime.clock.os logs duration lwt_log fmt.cli fmt.tty logs.fmt logs.cli))


### PR DESCRIPTION
The goal is to move to (a) cstruct-free and (b) smaller binary size.

This is the path towards using the same approach as ocaml-dns (a GADT map), and also what ocaml-tls did in recent years (remove the not supported enums, etc.). While this commit adds code, it removes ppx_cstruct. In subsequent commits, we'll remove more code, and likely result in a smaller (and thus more manageable) codebase.